### PR TITLE
chore: rename skill-devtool package to skill-lynx-devtool

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
     "@lynx-js/ai-plugin-lynx-debug": "workspace:*",
     "@lynx-js/ai-plugin-reactlynx": "workspace:*",
     "@lynx-js/skill-debug-info-remapping": "workspace:*",
-    "@lynx-js/skill-devtool": "workspace:*",
     "@lynx-js/skill-habitat-usage": "workspace:*",
+    "@lynx-js/skill-lynx-devtool": "workspace:*",
     "@lynx-js/skill-reactlynx-best-practices": "workspace:*",
     "@lynx-js/skill-trace-analysis": "workspace:*"
   },

--- a/packages/skills/lynx-devtool/package.json
+++ b/packages/skills/lynx-devtool/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@lynx-js/skill-devtool",
+  "name": "@lynx-js/skill-lynx-devtool",
   "version": "0.1.0",
   "private": true,
   "type": "module",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,12 +29,12 @@ importers:
       '@lynx-js/skill-debug-info-remapping':
         specifier: workspace:*
         version: link:packages/skills/debug-info-remapping
-      '@lynx-js/skill-devtool':
-        specifier: workspace:*
-        version: link:packages/skills/lynx-devtool
       '@lynx-js/skill-habitat-usage':
         specifier: workspace:*
         version: link:packages/skills/habitat-usage
+      '@lynx-js/skill-lynx-devtool':
+        specifier: workspace:*
+        version: link:packages/skills/lynx-devtool
       '@lynx-js/skill-reactlynx-best-practices':
         specifier: workspace:*
         version: link:packages/skills/reactlynx-best-practices


### PR DESCRIPTION
## Summary
* Renames `@lynx-js/skill-devtool` to `@lynx-js/skill-lynx-devtool` in `packages/skills/lynx-devtool/package.json`.
* Updates corresponding dependency reference in the root `package.json`.
* Updates `pnpm-lock.yaml` to reflect the package name change.