### PR TITLE
fix(lynx-devtool): use latest session and remove redundant type casting

### DIFF
--- a/packages/skills/lynx-devtool/examples/cdp.md
+++ b/packages/skills/lynx-devtool/examples/cdp.md
@@ -11,7 +11,7 @@ node <path_to_the_skill>/scripts/index.mjs cdp -m <method> [options] [params]
 
 - `-m, --method <method>`: The CDP method name (e.g., `DOM.getDocument`, `Runtime.evaluate`).
 - `-c, --client <clientId>`: (Optional) The Client ID. If omitted, uses the first available client.
-- `-s, --session <sessionId>`: (Optional) The Session ID. If omitted, uses the first available session.
+- `-s, --session <sessionId>`: (Optional) The Session ID. If omitted, uses the latest available session.
 - `[params]`: (Optional) JSON string of parameters for the command.
 
 Example:

--- a/packages/skills/lynx-devtool/references/get-console.md
+++ b/packages/skills/lynx-devtool/references/get-console.md
@@ -11,7 +11,7 @@ node scripts/index.mjs get-console [options]
 ## Options
 
 - `-c, --client <clientId>`: Client ID. If not provided, the command will attempt to discover the first available client.
-- `-s, --session <sessionId>`: Session ID. If not provided, the command will attempt to discover the first available session.
+- `-s, --session <sessionId>`: Session ID. If not provided, the command will attempt to discover the latest available session.
 - `--offset <number>`: The number of console messages to skip before returning results. Default is `0`.
 - `--limit <number>`: The maximum number of console messages to return. Values are clamped between 1 and 100.
 - `--include-stack-traces`: By default, only error messages include stack traces. Set this flag to include stack traces for all message types.

--- a/packages/skills/lynx-devtool/references/get-sources.md
+++ b/packages/skills/lynx-devtool/references/get-sources.md
@@ -11,7 +11,7 @@ node scripts/index.mjs get-sources [options]
 ## Options
 
 - `-c, --client <clientId>`: Client ID. If not provided, the command will attempt to discover the first available client.
-- `-s, --session <sessionId>`: Session ID. If not provided, the command will attempt to discover the first available session.
+- `-s, --session <sessionId>`: Session ID. If not provided, the command will attempt to discover the latest available session.
 
 ## Behavior
 

--- a/packages/skills/lynx-devtool/references/take-screenshot.md
+++ b/packages/skills/lynx-devtool/references/take-screenshot.md
@@ -11,7 +11,7 @@ node scripts/index.mjs take-screenshot [options]
 ## Options
 
 - `-c, --client <clientId>`: Client ID. If not provided, the command will attempt to discover the first available client.
-- `-s, --session <sessionId>`: Session ID. If not provided, the command will attempt to discover the first available session.
+- `-s, --session <sessionId>`: Session ID. If not provided, the command will attempt to discover the latest available session.
 - `-o, --output <path>`: The file path where the screenshot will be saved. Defaults to `screenshot-<timestamp>.jpeg` in the current working directory.
 
 ## Behavior

--- a/packages/skills/lynx-devtool/src/commands/cdp.ts
+++ b/packages/skills/lynx-devtool/src/commands/cdp.ts
@@ -4,7 +4,7 @@
 
 import type { Connector } from '@lynx-js/devtool-connector';
 import type { Command } from 'commander';
-import { getFirstClient, getFirstSession } from './utils.ts';
+import { getFirstClient, getLatestSession } from './utils.ts';
 
 export function registerCdpCommand(program: Command, connector: Connector) {
   program
@@ -32,7 +32,7 @@ export function registerCdpCommand(program: Command, connector: Connector) {
       }
 
       if (!sessionId) {
-        sessionId = await getFirstSession(connector, clientId);
+        sessionId = await getLatestSession(connector, clientId);
       }
 
       const params = paramsStr ? JSON.parse(paramsStr) : {};

--- a/packages/skills/lynx-devtool/src/commands/get-console.ts
+++ b/packages/skills/lynx-devtool/src/commands/get-console.ts
@@ -6,7 +6,7 @@ import { ReadableStream } from 'node:stream/web';
 import { setTimeout } from 'node:timers/promises';
 import type { Connector } from '@lynx-js/devtool-connector';
 import type { Command } from 'commander';
-import { getFirstClient, getFirstSession } from './utils.ts';
+import { getFirstClient, getLatestSession } from './utils.ts';
 
 interface ConsoleCallFrame {
   url: string;
@@ -81,7 +81,7 @@ export function registerGetConsoleCommand(
       }
 
       if (!sessionId) {
-        sessionId = await getFirstSession(connector, clientId);
+        sessionId = await getLatestSession(connector, clientId);
       }
 
       const numericSessionId = Number(sessionId);

--- a/packages/skills/lynx-devtool/src/commands/get-sources.ts
+++ b/packages/skills/lynx-devtool/src/commands/get-sources.ts
@@ -6,7 +6,7 @@ import { ReadableStream } from 'node:stream/web';
 import { setTimeout } from 'node:timers/promises';
 import type { Connector } from '@lynx-js/devtool-connector';
 import type { Command } from 'commander';
-import { getFirstClient, getFirstSession } from './utils.ts';
+import { getFirstClient, getLatestSession } from './utils.ts';
 
 interface ScriptParsedEvent {
   scriptId: string;
@@ -37,7 +37,7 @@ export function registerGetSourcesCommand(
       }
 
       if (!sessionId) {
-        sessionId = await getFirstSession(connector, clientId);
+        sessionId = await getLatestSession(connector, clientId);
       }
 
       const numericSessionId = Number(sessionId);

--- a/packages/skills/lynx-devtool/src/commands/take-screenshot.ts
+++ b/packages/skills/lynx-devtool/src/commands/take-screenshot.ts
@@ -7,7 +7,7 @@ import { ReadableStream } from 'node:stream/web';
 import { setTimeout } from 'node:timers/promises';
 import type { Connector } from '@lynx-js/devtool-connector';
 import type { Command } from 'commander';
-import { getFirstClient, getFirstSession } from './utils.ts';
+import { getFirstClient, getLatestSession } from './utils.ts';
 
 export function registerTakeScreenshotCommand(
   program: Command,
@@ -41,7 +41,7 @@ export function registerTakeScreenshotCommand(
       }
 
       if (!sessionId) {
-        sessionId = await getFirstSession(connector, clientId);
+        sessionId = await getLatestSession(connector, clientId);
       }
 
       const numericSessionId = Number(sessionId);

--- a/packages/skills/lynx-devtool/src/commands/utils.ts
+++ b/packages/skills/lynx-devtool/src/commands/utils.ts
@@ -12,14 +12,16 @@ export async function getFirstClient(connector: Connector): Promise<string> {
   return firstClient.id;
 }
 
-export async function getFirstSession(
+export async function getLatestSession(
   connector: Connector,
   clientId: string,
 ): Promise<string> {
   const sessions = await connector.sendListSessionMessage(clientId);
-  const firstSession = sessions[0];
-  if (!firstSession) {
+  if (!sessions || sessions.length === 0) {
     throw new Error(`No available sessions found for client: ${clientId}`);
   }
-  return String(firstSession.session_id);
+  const latestSession = sessions.reduce((max, session) =>
+    session.session_id > max.session_id ? session : max,
+  );
+  return String(latestSession.session_id);
 }


### PR DESCRIPTION
## Summary
- Renamed `getFirstSession` to `getLatestSession` to accurately reflect its behavior.
- Removed redundant `Number()` type casting during session reduction in `utils.ts`.
- Updated examples and references documentation to explicitly state the latest session is used when omitted.