### PR TITLE
chore: add renovate configuration

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,12 @@
+{
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "extends": [
+        "config:recommended",
+        "schedule:earlyMondays",
+        "group:allNonMajor"
+    ],
+    "baseBranchPatterns": [
+        "main"
+    ],
+    "rangeStrategy": "bump"
+}


### PR DESCRIPTION
## Summary
- Adds `.github/renovate.json` to automate dependency updates.
- Targets `main` via `baseBranchPatterns` but PR opens against `release` (the repo's default branch) to ensure Renovate reads it.
- Configures early Mondays updates and groups all non-major updates.