### PR TITLE
chore: remove block-release-pr job and release branch trigger

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,21 +2,12 @@ name: Test
 
 on:
   pull_request:
-    branches: [main, release]
+    branches: [main]
   push:
     branches: [main]
   workflow_dispatch:
 
 jobs:
-  block-release-pr:
-    if: github.event_name == 'pull_request' && github.base_ref == 'release'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Block PR to release branch
-        run: |
-          echo "::error::PRs to release branch are not allowed. This branch is managed by GitHub Actions only."
-          exit 1
-
   code-style-check:
     runs-on: ubuntu-latest
     timeout-minutes: 10


### PR DESCRIPTION
## Summary
- Removes the `block-release-pr` job from `.github/workflows/test.yml` as it is no longer useful.
- Removes the `release` branch trigger for `pull_request` events in the `test.yml` workflow.