### PR TITLE
ci: block PRs targeting release branch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,14 @@
+name: Block PR
+
+on:
+  pull_request:
+    branches: [release]
+
+jobs:
+  block-release-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Block PR to release branch
+        run: |
+          echo "::error::PRs to release branch are not allowed. This branch is managed by GitHub Actions only."
+          exit 1


### PR DESCRIPTION
Retains the job that prevents PRs from being opened against the `release` branch, as this was removed from the `main` branch workflow.