### PR TITLE
ci(sync): dynamically preserve all non-generated files on release branch

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -49,13 +49,12 @@ jobs:
           git fetch origin release || git checkout --orphan release
           git checkout release || git checkout --orphan release
           
-          find . -maxdepth 1 \
-            -not -name '.git' \
-            -not -name 'AGENTS.md' \
-            -not -name '.github' \
-            -not -name '.' \
-            -not -name 'dist' \
-            -exec rm -rf {} +
+          # Only remove the files/folders that are generated in dist/.
+          # This safely preserves any release-specific files (like .github, AGENTS.md, etc.)
+          # while perfectly cleaning up old/deleted skills inside the generated directories.
+          ls -A dist | while read -r item; do
+            rm -rf "$item"
+          done
           
           cp -R dist/. . && rm -rf dist
           


### PR DESCRIPTION
## Summary
- Instead of hardcoding a whitelist of files (`AGENTS.md`, `.github`) to preserve on the `release` branch, the sync script now dynamically identifies all top-level files/directories generated in `dist/` and completely replaces ONLY those.
- This ensures any new differentiated files added to the `release` branch (e.g. `.gitignore`, `package.json`) will be naturally preserved without needing future updates to `sync.yml`.
- Any skills or plugins deleted from `main` are still accurately removed from the `release` branch since their parent directories (`skills/`, `plugins/`) are completely wiped out before copying.