### PR TITLE
fix: clean skills/ and plugins/ output directories before rebuild

### DIFF
--- a/export-skills.mjs
+++ b/export-skills.mjs
@@ -3,6 +3,7 @@
 // LICENSE file in the root directory of this source tree.
 import { execSync, spawn } from 'node:child_process';
 import { readFileSync } from 'node:fs';
+import { rm } from 'node:fs/promises';
 import { createRequire } from 'node:module';
 import { dirname, resolve } from 'node:path';
 
@@ -63,11 +64,13 @@ function runBuildPlugin(skillPath, targetDir) {
   });
 }
 
+const skillsOutputDir = resolve(process.cwd(), 'skills');
+await rm(skillsOutputDir, { recursive: true, force: true });
+
 for (const skill of skills) {
   const { name, path: skillPath } = skill;
   const targetDir = resolve(
-    process.cwd(),
-    'skills',
+    skillsOutputDir,
     name.replace('@lynx-js/skill-', ''),
   );
   await runBuildPlugin(skillPath, targetDir);

--- a/packages/cmd/build-marketplace/src/main.ts
+++ b/packages/cmd/build-marketplace/src/main.ts
@@ -3,7 +3,7 @@
 // LICENSE file in the root directory of this source tree.
 
 import { readFileSync } from 'node:fs';
-import { mkdir, writeFile } from 'node:fs/promises';
+import { mkdir, rm, writeFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
 import { exportPlugin } from 'build-plugin';
 import { Command } from 'commander';
@@ -24,6 +24,9 @@ async function buildMarketplace(pkgDir: string) {
 
   const plugins: Array<{ name: string; description?: string; source: string }> =
     [];
+
+  // Clean plugins output directory before rebuilding
+  await rm(resolve(pkgDir, 'plugins'), { recursive: true, force: true });
 
   // PLUGINS
   for (const dep in dependencies) {


### PR DESCRIPTION
## Summary

- Add `rm -rf` cleanup for `skills/` directory in `export-skills.mjs` before exporting skills
- Add `rm -rf` cleanup for `plugins/` directory in `build-marketplace` before exporting plugins
- Prevents stale files from previously-removed skills/plugins lingering in build output