### PR TITLE
fix: improve skill validation test and rename CI job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Changeset Check
         run: pnpm changeset status --since=origin/main
 
-  validate-new-skills:
+  validate-skills:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:

--- a/export-skills.mjs
+++ b/export-skills.mjs
@@ -3,6 +3,7 @@
 // LICENSE file in the root directory of this source tree.
 import { execSync, spawn } from 'node:child_process';
 import { readFileSync } from 'node:fs';
+import { rm } from 'node:fs/promises';
 import { createRequire } from 'node:module';
 import { dirname, resolve } from 'node:path';
 
@@ -63,11 +64,13 @@ function runBuildPlugin(skillPath, targetDir) {
   });
 }
 
+const skillsOutputDir = resolve(process.cwd(), 'skills');
+await rm(skillsOutputDir, { recursive: true, force: true });
+
 for (const skill of skills) {
   const { name, path: skillPath } = skill;
   const targetDir = resolve(
-    process.cwd(),
-    'skills',
+    skillsOutputDir,
     name.replace('@lynx-js/skill-', ''),
   );
   await runBuildPlugin(skillPath, targetDir);

--- a/packages/cmd/build-marketplace/src/main.ts
+++ b/packages/cmd/build-marketplace/src/main.ts
@@ -3,7 +3,7 @@
 // LICENSE file in the root directory of this source tree.
 
 import { readFileSync } from 'node:fs';
-import { mkdir, writeFile } from 'node:fs/promises';
+import { mkdir, rm, writeFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
 import { exportPlugin } from 'build-plugin';
 import { Command } from 'commander';
@@ -24,6 +24,9 @@ async function buildMarketplace(pkgDir: string) {
 
   const plugins: Array<{ name: string; description?: string; source: string }> =
     [];
+
+  // Clean plugins output directory before rebuilding
+  await rm(resolve(pkgDir, 'plugins'), { recursive: true, force: true });
 
   // PLUGINS
   for (const dep in dependencies) {

--- a/scripts/validate-skills.test.mjs
+++ b/scripts/validate-skills.test.mjs
@@ -21,6 +21,10 @@ const SKIP_LIST = new Map([
 ]);
 
 const ALLOWED_PREFIX_RE = /^(lynx-|reactlynx-|ttml-|perflab-)/;
+const ALLOWED_PREFIX_LABEL = ALLOWED_PREFIX_RE.source
+  .slice(2, -2)
+  .split('|')
+  .join(' / ');
 
 function getSkillDirs() {
   if (!existsSync(SKILLS_DIR)) return [];
@@ -47,6 +51,13 @@ function readSkillName(skillDir) {
 }
 
 describe('skills validation', () => {
+  it('skills directory exists', () => {
+    assert.ok(
+      existsSync(SKILLS_DIR),
+      `skills directory not found: ${SKILLS_DIR}`,
+    );
+  });
+
   const skills = getSkillDirs();
 
   if (skills.length === 0) {
@@ -79,7 +90,7 @@ describe('skills validation', () => {
           );
         });
 
-        it('name starts with an allowed prefix (lynx- / reactlynx- / ttml-)', () => {
+        it(`name starts with an allowed prefix (${ALLOWED_PREFIX_LABEL})`, () => {
           assert.match(
             skillName,
             ALLOWED_PREFIX_RE,

--- a/scripts/validate-skills.test.mjs
+++ b/scripts/validate-skills.test.mjs
@@ -22,9 +22,9 @@ const SKIP_LIST = new Map([
 
 const ALLOWED_PREFIXES = ['lynx-', 'reactlynx-', 'ttml-', 'perflab-'];
 const ALLOWED_PREFIX_RE = new RegExp(
-  `^(${ALLOWED_PREFIXES
-    .map((prefix) => prefix.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
-    .join('|')})`,
+  `^(${ALLOWED_PREFIXES.map((prefix) =>
+    prefix.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'),
+  ).join('|')})`,
 );
 const ALLOWED_PREFIX_LABEL = ALLOWED_PREFIXES.join(' / ');
 

--- a/scripts/validate-skills.test.mjs
+++ b/scripts/validate-skills.test.mjs
@@ -20,11 +20,13 @@ const SKIP_LIST = new Map([
   ['habitat-usage', 'name does not start with an allowed prefix'],
 ]);
 
-const ALLOWED_PREFIX_RE = /^(lynx-|reactlynx-|ttml-|perflab-)/;
-const ALLOWED_PREFIX_LABEL = ALLOWED_PREFIX_RE.source
-  .slice(2, -2)
-  .split('|')
-  .join(' / ');
+const ALLOWED_PREFIXES = ['lynx-', 'reactlynx-', 'ttml-', 'perflab-'];
+const ALLOWED_PREFIX_RE = new RegExp(
+  `^(${ALLOWED_PREFIXES
+    .map((prefix) => prefix.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+    .join('|')})`,
+);
+const ALLOWED_PREFIX_LABEL = ALLOWED_PREFIXES.join(' / ');
 
 function getSkillDirs() {
   if (!existsSync(SKILLS_DIR)) return [];


### PR DESCRIPTION
## Summary

- Rename CI job from `validate-new-skills` to `validate-skills`
- Add existence check for `skills/` directory in validation test
- Derive allowed prefix label dynamically from regex to keep test description in sync