### PR TITLE
chore: mark selected skill packages private

### DIFF
--- a/packages/skills/habitat-usage/package.json
+++ b/packages/skills/habitat-usage/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@lynx-js/skill-habitat-usage",
   "version": "0.0.1",
+  "private": true,
   "description": "Guidance on using Habitat to manage multi-repo source and asset dependencies via .habitat/DEPS and hab sync, plus troubleshooting common sync failures.",
   "type": "module",
   "files": [

--- a/packages/skills/lynx-fiber-element/package.json
+++ b/packages/skills/lynx-fiber-element/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@lynx-js/skill-lynx-fiber-element",
   "version": "0.0.2",
+  "private": true,
   "description": "Build Lynx apps directly with FiberElement Element PAPI APIs from @lynx-js/type-element-api.",
   "repository": {
     "url": "https://github.com/lynx-community/skills"
@@ -19,8 +20,5 @@
   "devDependencies": {},
   "engines": {
     "node": ">=18"
-  },
-  "publishConfig": {
-    "access": "public"
   }
 }


### PR DESCRIPTION
## Summary
- Mark `@lynx-js/skill-habitat-usage` as private.
- Mark `@lynx-js/skill-lynx-fiber-element` as private and remove its public publish config.

## Validation
- `pnpm install`
- `pnpm check`

Base branch: `main`.