### PR TITLE
ci: use lynx-skills-sync-bot token for release sync

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -18,6 +21,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -44,11 +48,23 @@ jobs:
           cp README.md CONTRIBUTING.md dist/
           tree ./dist
 
+      - name: Generate release sync token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.RELEASE_SYNC_APP_ID }}
+          private-key: ${{ secrets.RELEASE_SYNC_APP_PRIVATE_KEY }}
+          permission-contents: write
+
       - name: Push to release branch
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
         run: |
           STAGE_DIR=$(mktemp -d)
           cp -R dist/. "$STAGE_DIR"
 
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
           git fetch origin release || true
           if git show-ref --verify --quiet refs/remotes/origin/release; then
             git checkout release
@@ -63,17 +79,16 @@ jobs:
           done
 
           cp -R "$STAGE_DIR"/. . && rm -rf "$STAGE_DIR"
-          
-          git config --local user.name "github-actions[bot]"
-          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+
+          APP_USER_ID="$(gh api "/users/${APP_SLUG}[bot]" --jq .id)"
+          git config --local user.name "${APP_SLUG}[bot]"
+          git config --local user.email "${APP_USER_ID}+${APP_SLUG}[bot]@users.noreply.github.com"
           git add -A
-          
+
           if git diff --cached --quiet; then
             echo "No changes to commit, skipping"
           else
-            git commit \
-              --author="$(git log -1 --format='%an <%ae>' ${{ github.sha }})" \
-              -m "$(git log -1 --format='%B' ${{ github.sha }})"
+            git commit -m "$(git log -1 --format='%B' "${{ github.sha }}")"
             git show HEAD
             git push origin release
           fi


### PR DESCRIPTION
## Summary

- Generate a GitHub App installation token for the release sync workflow.
- Use that token for the release branch fetch/push path instead of the default GITHUB_TOKEN.
- Commit release output as the GitHub App bot instead of inheriting the triggering developer identity.

## Why

The release branch is protected by rulesets, so the workflow needs to push as the dedicated bypass-enabled GitHub App rather than as github-actions[bot] or a developer identity.

## Validation

- git diff --check -- .github/workflows/sync.yml
- pnpm check