### PR TITLE
ci: include original author in release sync message

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -88,7 +88,14 @@ jobs:
           if git diff --cached --quiet; then
             echo "No changes to commit, skipping"
           else
-            git commit -m "$(git log -1 --format='%B' "${{ github.sha }}")"
+            SOURCE_AUTHOR="$(git log -1 --format='%an <%ae>' "${{ github.sha }}")"
+            SOURCE_SHA="$(git rev-parse "${{ github.sha }}")"
+            SOURCE_MESSAGE="$(git log -1 --format='%B' "${{ github.sha }}")"
+
+            git commit \
+              -m "$SOURCE_MESSAGE" \
+              -m "Original-author: ${SOURCE_AUTHOR}" \
+              -m "Source-commit: ${SOURCE_SHA}"
             git show HEAD
             git push origin release
           fi


### PR DESCRIPTION
## Summary

- Preserve the source commit message when syncing to release.
- Append the triggering commit's original author and source SHA to the generated release commit message.
- Keep the actual release commit author/committer as the GitHub App bot for ruleset bypass.

## Why

The release sync commit must be created by the bypass-enabled GitHub App, but the generated commit should still make the original contributor visible in the commit message.

## Validation

- git diff --check -- .github/workflows/sync.yml
- pnpm check