### PR TITLE
ci: preserve source author for release sync

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -93,8 +93,8 @@ jobs:
             SOURCE_MESSAGE="$(git log -1 --format='%B' "${{ github.sha }}")"
 
             git commit \
+              --author="$SOURCE_AUTHOR" \
               -m "$SOURCE_MESSAGE" \
-              -m "Original-author: ${SOURCE_AUTHOR}" \
               -m "Source-commit: ${SOURCE_SHA}"
             git show HEAD
             git push origin release


### PR DESCRIPTION
## Summary

- Set the generated release sync commit author to the triggering source commit author.
- Keep the committer and push identity as the bypass-enabled GitHub App bot.
- Keep the source commit SHA in the generated release commit message for traceability.

## Why

The repository's default branch is release, so GitHub contributor statistics need the release sync commit's Git author field to match the original contributor while ruleset bypass continues to use the GitHub App token.

## Validation

- git diff --check -- .github/workflows/sync.yml
- pnpm check