### PR TITLE
refactor: reactlynx-best-practices skill

### DIFF
--- a/.changeset/reactlynx-best-practices-refactor.md
+++ b/.changeset/reactlynx-best-practices-refactor.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/skill-reactlynx-best-practices": minor
+---
+
+Refactor ReactLynx best practices to remove the `@ast-grep/napi` runtime dependency, add lightweight scanner coverage for lifecycle usage, and expand the skill guidance with dual-thread, main-thread script, code-splitting, and profiling rules.

--- a/packages/skills/reactlynx-best-practices/SKILL.md
+++ b/packages/skills/reactlynx-best-practices/SKILL.md
@@ -1,151 +1,130 @@
 ---
 name: reactlynx-best-practices
-description: ReactLynx best practices covering dual-thread architecture and React patterns. Provides rules reference for writing, static analysis for reviewing, and auto-fix for refactoring.
+description: Review, write, and refactor ReactLynx code using dual-thread, lifecycle, main-thread script, code-splitting, and profiling best practices.
 ---
 
 # ReactLynx Best Practices
 
-ReactLynx best practices covering dual-thread architecture and React patterns. Provides rules reference for writing, static analysis for reviewing, and auto-fix for refactoring.
+Use this skill when writing, reviewing, or refactoring ReactLynx code. ReactLynx follows the React programming model, but Lynx's dual-thread runtime changes how side effects, lifecycle timing, event handlers, and main-thread scripts should be reasoned about.
+
+This skill intentionally does not require `@ast-grep/napi` or any native parser at runtime. The bundled scanner is a lightweight heuristic helper for common issues. The agent must still read the code and apply the rule documents in `rules/*.md`.
 
 ## When to Apply
 
-This skill should be used when:
-- **Writing** new ReactLynx components or application → Reference rules as guidelines
-- **Reviewing** existing ReactLynx code → Use scanner to detect issues
-- **Refactoring** ReactLynx code → Use auto-fix with user approval
+- Writing new ReactLynx components or application code.
+- Reviewing ReactLynx code for thread-boundary, lifecycle, event, code-splitting, or performance issues.
+- Refactoring code that calls `lynx.getJSModule`, `NativeModules`, `runOnMainThread`, `runOnBackground`, `lazy`, `Suspense`, or `useLayoutEffect`.
+- Investigating performance traces that include ReactLynx render, diff, commit, patch, or setState events.
 
-## Input
+## Official References
 
-This skill accepts the following inputs:
+- Thinking in ReactLynx: https://lynxjs.org/next/react/thinking-in-reactlynx.html
+- Rendering Process and Lifecycle: https://lynxjs.org/next/react/lifecycle.html
+- Main Thread Script: https://lynxjs.org/next/react/main-thread-script.html
+- Code Splitting: https://lynxjs.org/next/react/code-splitting.html
+- Performance Profiling: https://lynxjs.org/next/react/performance/profiling
 
-| Input | Required | Description |
-|-------|----------|-------------|
-| `sourceCode` | No | The ReactLynx source code to analyze (string or file path) |
-| `mode` | No | Workflow mode: `writing`, `review`, or `refactor`. Auto-detected if not specified |
+## Workflow
 
-### Mode Auto-Detection
+### 1. Classify the task
 
-When `mode` is not explicitly provided, the skill will determine the appropriate mode based on context:
+Use one of these modes:
 
-| Context | Auto-Selected Mode |
-|---------|-------------------|
-| User is asking for best practices or guidelines | `writing` |
-| User wants to check/analyze existing code for issues | `review` |
-| User wants to fix/refactor code with auto-fixes | `refactor` |
+| Mode | Use when |
+|------|----------|
+| `writing` | The user asks for new ReactLynx code or best-practice guidance |
+| `review` | The user asks to check, audit, explain, or validate existing code |
+| `refactor` | The user asks to fix or rewrite existing code |
 
-## Workflow Modes
+If the mode is not explicit, infer it from the user's wording. Prefer `review` before `refactor` when code has not been inspected yet.
 
-### 📝 Writing Mode
+### 2. Inspect the code
 
-When writing new ReactLynx code, reference the rules in `rules/*.md` as best practice guidelines. See also the [Rules](#rules) section below for a summary of all available rules.
+For repository work, search before editing:
 
-**Use this mode when:**
-- User is creating new ReactLynx components or application
-- User asks "how should I write..." or "what's the best practice for..."
-- No existing code to analyze
+```bash
+rg "lynx.getJSModule|NativeModules|useLayoutEffect|main-thread:|runOnMainThread|runOnBackground|lazy\\(|Suspense|background only" <target>
+```
 
-### 🔍 Review Mode
+Read nearby components, custom hooks, custom components that forward event handlers, Rspeedy config, and performance-related code before making changes.
 
-When reviewing code, do both:
-1. Use the scanner (`scripts/index.mjs`) to analyze source code for issues
-2. Combine findings with `rules/*.md` explanations to generate a rule-aware report
+### 3. Run the helper scanner when source is available
 
-**Use this mode when:**
-- User provides code and asks to "check", "review", or "analyze" it
-- User wants to know if their code has any issues
-- User asks "is this code correct?" or "any problems with this?"
-
-**Report requirements (must include):**
-- Scan summary from `workflow.reviewCode(sourceCode)`
-- Rule interpretation for each hit `ruleId` from `rules/<ruleId>.md`
-- Severity/impact context from rule metadata (`impact`, `impactDescription`)
-- Actionable suggestions based on rule guidance (not only raw diagnostics)
+The scanner catches common background-only and lifecycle issues. It is not a complete parser and must not replace code review.
 
 ```bash
 node -e "
 import fs from 'fs';
 import { ReactLynxWorkflow, formatScanReport } from '<path_to_skill>/scripts/index.mjs';
 
-// <sourceCode>: string (source code) or file path
-const input = '<sourceCode>';
+const input = '<sourceCodeOrFilePath>';
 const sourceCode = fs.existsSync(input) ? fs.readFileSync(input, 'utf-8') : input;
-
 const workflow = new ReactLynxWorkflow('review');
 const summary = workflow.reviewCode(sourceCode);
 console.log(formatScanReport(summary));
 "
 ```
 
-### 🔧 Refactor Mode
+### 4. Apply the rule checklist
 
-When refactoring, generate a fix plan and **ask the user before applying**.  
-In this mode, output must include both script results and a rules-aware report.
+Always combine scanner output with these manual checks:
 
-**Use this mode when:**
-- User explicitly asks to "fix", "refactor", or "auto-fix" code
-- User wants to apply suggested fixes from a previous review
-- User says "please fix these issues" or "apply the fixes"
+- Dual-thread boundaries: render code may run on the main thread; side effects and native APIs must be background-only.
+- Background-only propagation: code called only from background-only code is background-only, but custom prop and custom hook boundaries often need an explicit `'background only'` directive.
+- Lifecycle: `useLayoutEffect` is unsupported; use `useEffect` for background side effects or main-thread layout events/refs for layout reads.
+- Events: normal `bind*`/`catch*` handlers run on the background thread; `main-thread:*` handlers require `'main thread'` and have stricter limitations.
+- MTS: captured values must be JSON-serializable, captured variables cannot be modified, nested main-thread functions are unsupported, and cross-thread calls must use `runOnMainThread()` or `runOnBackground()`.
+- Shared modules: import helpers with `with { runtime: 'shared' }` only for code sharing, not state sharing.
+- Code splitting: lazy components need default exports, `Suspense`, CSS scope awareness, and error handling for important boundaries.
+- Profiling: use trace events and readable `displayName` values to identify hot render/diff/update paths before optimizing.
 
-**Report requirements (must include):**
-- Pre-fix scan summary and rule-aware interpretation
-- Fix plan summary (`fixableIssues`, `manualIssues`, per-file changes)
-- Post-fix outcome (`appliedFixes`) and remaining manual issues
+### 5. Refactor safely
 
-```
-TOOL CALL: AskUserQuestion(
-  question: "🔧 Found {fixableIssues} auto-fixable issues. Would you like me to apply these fixes?",
-  options: ["Yes, apply fixes", "No, show me the issues first", "Skip auto-fix"]
-)
-```
+For refactor mode:
+
+1. Report current findings first.
+2. Explain which fixes are mechanical and which require human design judgment.
+3. Apply only scoped changes.
+4. Re-run the helper scanner or package tests after edits.
+
+Use auto-fixes only as suggestions. The current auto-fixes are designed for `detect-background-only` diagnostics and should be reviewed before applying.
 
 ```bash
 node -e "
 import fs from 'fs';
 import { ReactLynxWorkflow, formatFixPlan } from '<path_to_skill>/scripts/index.mjs';
 
-// <sourceCode>: string (source code) or file path
-const input = '<sourceCode>';
+const input = '<sourceCodeOrFilePath>';
 const sourceCode = fs.existsSync(input) ? fs.readFileSync(input, 'utf-8') : input;
-
 const workflow = new ReactLynxWorkflow('refactor');
 workflow.reviewCode(sourceCode);
 const plan = workflow.generateFixPlan();
 
-if (plan && plan.fixableIssues > 0) {
+if (plan) {
   console.log(formatFixPlan(plan));
-  // ASK USER: 'Would you like me to apply these auto-fixes?'
-  // If yes:
-  const { fixed, appliedFixes } = workflow.applyAutoFixes(sourceCode);
-  console.log('Fixed code:', fixed);
 }
 "
 ```
 
 ## Rules
 
-All rules are documented in the `rules/` directory as Markdown files:
-
-| Rule | Impact | Description |
-|------|--------|-------------|
-| [detect-background-only](./rules/detect-background-only.md) | CRITICAL | Native APIs in background contexts, use `'background only'` directive |
-| [proper-event-handlers](./rules/proper-event-handlers.md) | MEDIUM | Correct event handler usage |
-| [main-thread-scripts-guide](./rules/main-thread-scripts-guide.md) | MEDIUM | Main thread scripts guide |
-| [hoist-static-jsx](./rules/hoist-static-jsx.md) | LOW | Performance optimization |
+| Rule | Impact | Use for |
+|------|--------|---------|
+| [detect-background-only](./rules/detect-background-only.md) | CRITICAL | `lynx.getJSModule`, `NativeModules`, `'background only'`, custom event/hook boundaries |
+| [avoid-use-layout-effect](./rules/avoid-use-layout-effect.md) | MEDIUM | Lifecycle and layout reads |
+| [proper-event-handlers](./rules/proper-event-handlers.md) | MEDIUM | `bindtap`, `catchtap`, propagation, dataset, custom prop handlers |
+| [main-thread-scripts-guide](./rules/main-thread-scripts-guide.md) | MEDIUM | `main-thread:*`, `useMainThreadRef`, cross-thread calls, shared modules |
+| [code-splitting](./rules/code-splitting.md) | MEDIUM | `lazy`, `Suspense`, standalone lazy bundles, CSS bundle scope |
+| [performance-profiling](./rules/performance-profiling.md) | MEDIUM | ReactLynx trace events, flow IDs, displayName |
+| [hoist-static-jsx](./rules/hoist-static-jsx.md) | LOW | Static JSX and render cost |
 
 ## API Reference
-
-For complete type definitions:
-
-```
-TOOL CALL: Read(<path_to_skill>/scripts/index.d.ts)
-```
-
-### Exported Functions
 
 ```typescript
 function runSkill(source: string): Diagnostic[];
 function runSkillWithFixes(source: string): DiagnosticWithFix[];
 function analyzeBackgroundOnlyUsage(source: string): Diagnostic[];
+function analyzeLifecycleUsage(source: string): Diagnostic[];
 function generateFixes(source: string, diagnostic: Diagnostic): Fix[];
 function applyFix(source: string, fix: Fix): string;
 function applyFixes(source: string, fixes: Fix[]): string;
@@ -153,55 +132,11 @@ function formatScanReport(summary: ScanSummary): string;
 function formatFixPlan(plan: FixPlan): string;
 ```
 
-### Workflow Class
-
 ```typescript
 class ReactLynxWorkflow {
   constructor(mode: WorkflowMode);
   reviewCode(source: string): ScanSummary;
   generateFixPlan(): FixPlan | null;
   applyAutoFixes(source: string): { fixed: string; appliedFixes: Fix[] };
-}
-```
-
-### Key Types
-
-```typescript
-type WorkflowMode = 'writing' | 'review' | 'refactor';
-
-interface Diagnostic {
-  ruleId: string;
-  message: string;
-  severity: 'error' | 'warning' | 'info';
-  location: { start: { line: number; column: number }; end: { line: number; column: number } };
-}
-
-interface DiagnosticWithFix extends Diagnostic {
-  fixes?: Fix[];
-}
-
-interface Fix {
-  type: 'wrap-in-useEffect' | 'add-directive' | 'add-import' | 'move-to-event-handler';
-  description: string;
-  oldCode: string;
-  newCode: string;
-  location: { start: { line: number; column: number }; end: { line: number; column: number } };
-}
-
-interface ScanSummary {
-  totalFiles: number;
-  filesWithIssues: number;
-  totalIssues: number;
-  errorCount: number;
-  warningCount: number;
-  infoCount: number;
-  results: ScanResult[];
-}
-
-interface FixPlan {
-  totalIssues: number;
-  fixableIssues: number;
-  manualIssues: number;
-  files: FilePlan[];
 }
 ```

--- a/packages/skills/reactlynx-best-practices/package.json
+++ b/packages/skills/reactlynx-best-practices/package.json
@@ -20,9 +20,6 @@
     "dev": "rslib build --watch",
     "test": "rstest"
   },
-  "dependencies": {
-    "@ast-grep/napi": "^0.37.0"
-  },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.56.2",
     "@rslib/core": "catalog:rstack",

--- a/packages/skills/reactlynx-best-practices/rules/avoid-use-layout-effect.md
+++ b/packages/skills/reactlynx-best-practices/rules/avoid-use-layout-effect.md
@@ -1,0 +1,67 @@
+---
+title: Avoid useLayoutEffect
+ruleId: avoid-use-layout-effect
+impact: MEDIUM
+impactDescription: avoids relying on unsupported synchronous lifecycle behavior
+tags: lifecycle, dual-thread, layout, main-thread
+---
+
+## Avoid useLayoutEffect
+
+ReactLynx does not support `useLayoutEffect`. Lifecycle hooks run asynchronously on the background thread, so they do not have the synchronous "measure before paint" behavior that React DOM developers expect from `useLayoutEffect`.
+
+### Why It Matters
+
+ReactLynx optimizes first-screen rendering by letting the main thread render the first screen quickly while the background thread runs the full React runtime and later drives updates. Because lifecycles run on the background thread, layout reads inside a hook cannot synchronously block or adjust main-thread rendering.
+
+### Incorrect
+
+```tsx
+import { useLayoutEffect, useRef, useState } from '@lynx-js/react';
+
+function Tooltip() {
+  const ref = useRef(null);
+  const [height, setHeight] = useState(0);
+
+  useLayoutEffect(() => {
+    setHeight(ref.current?.getBoundingClientRect().height ?? 0);
+  }, []);
+
+  return <view ref={ref} style={{ height }} />;
+}
+```
+
+### Correct: Background Side Effect
+
+Use `useEffect` when the work is a normal background side effect and does not require synchronous layout.
+
+```tsx
+import { useEffect } from '@lynx-js/react';
+
+function App() {
+  useEffect(() => {
+    NativeModules.Analytics.track('mounted');
+  }, []);
+
+  return <view />;
+}
+```
+
+### Correct: Layout on Main Thread
+
+Use `main-thread:bindlayoutchange` or `main-thread:ref` when layout information must be read from the main thread.
+
+```tsx
+function App() {
+  function handleLayoutChange(event: MainThread.LayoutChangeEvent) {
+    'main thread';
+    event.currentTarget.setStyleProperty('opacity', '1');
+  }
+
+  return <view main-thread:bindlayoutchange={handleLayoutChange} />;
+}
+```
+
+### List Child Components
+
+`<list />` child component JS instances can be created before their real UI nodes are created. Regular `useEffect` and `ref` callbacks can run even when a list item is off-screen or reused. For UI-node visibility in a list, prefer `main-thread:ref`, whose callback and cleanup reflect when the actual element enters or leaves the main-thread UI tree.

--- a/packages/skills/reactlynx-best-practices/rules/code-splitting.md
+++ b/packages/skills/reactlynx-best-practices/rules/code-splitting.md
@@ -1,0 +1,77 @@
+---
+title: Code Splitting
+ruleId: code-splitting
+impact: MEDIUM
+impactDescription: improves load time while preserving lazy bundle boundaries
+tags: performance, lazy, suspense, bundle, css
+---
+
+## Code Splitting
+
+Use `lazy()` and `<Suspense>` to defer loading components until they are rendered. Treat each lazy component as its own Lynx bundle with its own CSS scope.
+
+### Basic Pattern
+
+```tsx
+import { Suspense, lazy } from '@lynx-js/react';
+
+const ProductPanel = lazy(() => import('./ProductPanel.jsx'));
+
+export function App() {
+  return (
+    <view>
+      <Suspense fallback={<text>Loading...</text>}>
+        <ProductPanel />
+      </Suspense>
+    </view>
+  );
+}
+```
+
+### Rules
+
+| Rule | Guidance |
+|------|----------|
+| Use default exports for lazy components | `lazy(() => import('./Panel.jsx'))` expects the imported module's default export |
+| Wrap lazy content in `<Suspense>` | Always provide a lightweight fallback near the lazy boundary |
+| Render-gate expensive chunks | Lazy chunks start downloading only when they are rendered |
+| Respect CSS bundle scope | Global CSS from the main bundle does not apply to lazy-loaded bundles, and lazy CSS does not leak back |
+| Add an ErrorBoundary for important chunks | Loading succeeds asynchronously, but component render errors still need React-style error handling |
+
+### Render-Gated Lazy Loading
+
+```tsx
+import { Suspense, lazy, useState } from '@lynx-js/react';
+
+const HeavyPanel = lazy(() => import('./HeavyPanel.jsx'));
+
+export function App() {
+  const [visible, setVisible] = useState(false);
+
+  return (
+    <view>
+      <view bindtap={() => setVisible(true)}>Load panel</view>
+      {visible && (
+        <Suspense fallback={<text>Loading...</text>}>
+          <HeavyPanel />
+        </Suspense>
+      )}
+    </view>
+  );
+}
+```
+
+### Standalone Lazy Bundles
+
+For modules built by a standalone Rspeedy producer project:
+- Enable `experimental_isLazyBundle: true` in the producer's ReactLynx plugin options.
+- Export the component as the producer entry default export.
+- In the consumer entry, import `@lynx-js/react/experimental/lazy/import` before rendering.
+- Load the remote bundle with dynamic `import()` and `with: { type: 'component' }`.
+
+### Review Checklist
+
+- Check whether large, initially hidden UI trees are statically imported.
+- Check whether lazy components have visible fallbacks and error handling.
+- Check whether CSS assumptions cross lazy bundle boundaries.
+- Check whether a lazy split actually improves the user path instead of delaying critical first-screen UI.

--- a/packages/skills/reactlynx-best-practices/rules/detect-background-only.md
+++ b/packages/skills/reactlynx-best-practices/rules/detect-background-only.md
@@ -8,29 +8,29 @@ tags: dual-thread, background-only, native-modules, lynx, directive
 
 ## Detect Background-Only API Usage
 
-Ensure `lynx.getJSModule` and `NativeModules` are only called in background thread contexts.
+Ensure `lynx.getJSModule` and `NativeModules` are only called in background-thread contexts.
 
 ### Why It Matters
 
-In ReactLynx's dual-thread architecture:
-- **Main thread**: Runs React component render functions, evaluates JSX
-- **Background thread**: Runs effects, event handlers, and native module calls
+In ReactLynx's dual-thread architecture, initial rendering can evaluate component code on the main thread while the background thread runs the full React runtime. Side effects unrelated to rendering are background-only. Calling background-only APIs during render can fail on the main thread because APIs such as `lynx.getJSModule` may not exist there.
 
-Calling `lynx.getJSModule` or `NativeModules` in main thread will:
-- Block UI rendering
-- Cause thread synchronization overhead
-- Lead to poor user experience
+Calling `lynx.getJSModule` or `NativeModules` from render or other shared code can:
+- Throw at runtime on the main thread
+- Increase main-thread bundle size by keeping side-effect code reachable
+- Break the compiler's background-only analysis
 
 ### Thread Context Reference
 
 | Context | Thread | Allowed |
 |---------|--------|---------|
-| Component render body | Main | ❌ |
-| `useEffect` / `useLayoutEffect` | Background | ✅ |
+| Component render body | Main + background during first render | ❌ |
+| `useEffect` | Background | ✅ |
+| `useLayoutEffect` | Unsupported in ReactLynx | ❌ |
 | `useImperativeHandle` | Background | ✅ |
 | `ref` callback | Background | ✅ |
 | Event handlers (`bindtap`, etc.) | Background | ✅ |
 | `'background only'` functions | Background | ✅ |
+| Module with `import 'background-only'` | Background | ✅ |
 
 **Incorrect (Main Thread - render scope):**
 
@@ -151,6 +151,8 @@ function fetchUser(id: string): Promise<User> {
 | Function calls native modules | ✅ Yes |
 | Function is called from useEffect | ✅ Yes (optional but recommended) |
 | Function is called from event handler | ✅ Yes (optional but recommended) |
+| Function is passed through a custom prop before reaching `bindtap` | ✅ Yes |
+| Callback is passed to a custom hook that eventually calls `useEffect` | ✅ Yes |
 | Function only does pure computation | ❌ No |
 | Function is called during render | ❌ No (will cause error) |
 
@@ -159,3 +161,45 @@ function fetchUser(id: string): Promise<User> {
 1. **Place directive first**: Must be the first statement in the function body
 2. **Use single or double quotes**: Both `'background only'` and `"background only"` work
 3. **Document intent**: The directive serves as documentation for other developers
+4. **Mark boundary callbacks**: Add the directive when callbacks cross custom component or custom hook boundaries because compiler analysis may not infer their background-only use
+5. **Prefer module directives for utility modules**: If every export in a module is background-only, use `import 'background-only'` at the top of that module
+
+### Custom Component Boundary
+
+When an event handler is passed as a custom prop, the compiler may not know that it eventually becomes `bindtap`. Mark the handler explicitly.
+
+```tsx
+function App() {
+  function handleTap() {
+    'background only';
+    NativeModules.Analytics.track('tap');
+  }
+
+  return <Button onClick={handleTap} />;
+}
+
+function Button({ onClick }) {
+  return <view bindtap={onClick} />;
+}
+```
+
+### Custom Hook Boundary
+
+When a custom hook wraps `useEffect`, mark the callback passed into that hook.
+
+```tsx
+function useMount(effect: () => void) {
+  useEffect(() => {
+    effect();
+  }, []);
+}
+
+function App() {
+  useMount(() => {
+    'background only';
+    lynx.getJSModule('Tracker').mount();
+  });
+
+  return <view />;
+}
+```

--- a/packages/skills/reactlynx-best-practices/rules/main-thread-scripts-guide.md
+++ b/packages/skills/reactlynx-best-practices/rules/main-thread-scripts-guide.md
@@ -202,3 +202,41 @@ function App() {
 | Cannot modify captured variables | Read-only access |
 | No nested main thread function definitions | Not supported |
 | `MainThreadRef.current` only accessible in main thread | Use `useMainThreadRef()` |
+| Class component constructor/getter/setter cannot be main thread functions | Use methods instead |
+
+### Cross-Thread Shared Modules
+
+Main thread functions cannot directly call plain helper functions unless those helpers are also main thread functions or imported through the shared runtime.
+
+```tsx
+import { clamp } from './math.js' with { runtime: 'shared' };
+
+function onScroll(event: MainThread.IScrollEvent) {
+  'main thread';
+  const opacity = clamp(event.detail.scrollTop / 100, 0, 1);
+  event.currentTarget.setStyleProperty('opacity', opacity.toString());
+}
+```
+
+Shared modules solve code sharing, not state sharing. Module variables are isolated between the main and background runtimes. Only identifiers directly imported with `with { runtime: 'shared' }` are recognized as shared; assigning them to a new variable can lose that property.
+
+### Third-Party Libraries
+
+When a main thread function needs a third-party utility, import the original utility as shared and wrap it in a main thread function. This creates a reusable boundary that static analysis can understand.
+
+```tsx
+import { animate as animateShared } from 'motion-dom' with { runtime: 'shared' };
+
+export function animate(...args: Parameters<typeof animateShared>) {
+  'main thread';
+  return animateShared(...args);
+}
+```
+
+### Review Checklist
+
+1. Use MTS for gesture-coupled or scroll-coupled visual updates, not ordinary business logic.
+2. Confirm every `main-thread:` handler points to a function with a top-level `'main thread'` directive.
+3. Check captured values for JSON serializability and avoid mutating captured values.
+4. Use `MainThreadRef` for main-thread state that must persist between calls.
+5. Use `runOnBackground()` when MTS needs to update React state or call background-only APIs.

--- a/packages/skills/reactlynx-best-practices/rules/performance-profiling.md
+++ b/packages/skills/reactlynx-best-practices/rules/performance-profiling.md
@@ -1,0 +1,66 @@
+---
+title: Performance Profiling
+ruleId: performance-profiling
+impact: MEDIUM
+impactDescription: makes render and update bottlenecks observable
+tags: performance, profiling, trace, displayName, setState
+---
+
+## Performance Profiling
+
+Use ReactLynx profiling to identify expensive renders, diff work, commits, patches, and unnecessary state updates. Profiling is most useful when run with realistic data and user flows.
+
+### Trace Events
+
+| Trace | Meaning |
+|-------|---------|
+| `ReactLynx::render::ComponentName` | Time spent executing a component render function |
+| `ReactLynx::diff::ComponentName` | Time spent diffing a component's virtual tree |
+| `ReactLynx::diffFinishNoPatch` | A diff finished without producing a UI patch |
+| `ReactLynx::commit` | Time spent committing updates to the native layer |
+| `ReactLynx::patch` | Time spent applying patches on the main thread |
+| `ReactLynx::setState` | A state update was scheduled, including changed state key metadata |
+
+### Enable and Interpret
+
+ReactLynx profiling instrumentation is enabled when Lynx engine profile recording is active. Lynx 3.0 or later provides APIs such as `lynx.performance.profileStart()`, `profileEnd()`, `profileMark()`, `profileFlowId()`, and `isProfileRecording()`.
+
+Use flow IDs to connect `setState` to the following diff, commit, and patch work. A repeated `diffFinishNoPatch` pattern usually means components are re-rendering without visible UI changes.
+
+### Component Names
+
+Production builds may minify component names. Set `displayName` for components that need readable profiling traces.
+
+```tsx
+function FeedItem() {
+  return <view />;
+}
+
+FeedItem.displayName = 'FeedItem';
+```
+
+If build tooling treats `displayName` assignments as side effects, wrap the assignment in a pure helper.
+
+```tsx
+function withDisplayName<T extends React.ComponentType<any>>(
+  Component: T,
+  name: string,
+): T {
+  Component.displayName = name;
+  return Component;
+}
+
+function FeedItem() {
+  return <view />;
+}
+
+export default /* @__PURE__ */ withDisplayName(FeedItem, 'FeedItem');
+```
+
+### Review Checklist
+
+- Profile production-like builds and realistic data, not tiny mock states.
+- Focus on components that render frequently or own large UI trees.
+- Use `React.memo`, `useMemo`, stable props, and narrower state ownership when traces show repeated no-patch diffs.
+- Keep readable `displayName` values for components that appear in hot paths.
+- Follow flow IDs from `setState` through diff, commit, and patch before choosing an optimization.

--- a/packages/skills/reactlynx-best-practices/rules/proper-event-handlers.md
+++ b/packages/skills/reactlynx-best-practices/rules/proper-event-handlers.md
@@ -171,3 +171,28 @@ function handleTap(event: MainThread.ITouchEvent) {
 3. **Use `dataset`** to pass data instead of closures when possible
 4. **Prefer `currentTarget`** over `target` for accessing the listening element's data
 5. **Native calls are safe** - event handlers run on background thread
+6. **Mark custom prop handlers** with `'background only'` when a handler is passed through a component prop before reaching `bindtap`
+7. **Use `main-thread:` events** only for gesture-coupled visual work that needs synchronous main-thread execution
+
+### Custom Component Boundaries
+
+The compiler recognizes direct event attributes such as `bindtap={handleTap}`. When a handler travels through a custom prop, mark the handler as background-only so it is not bundled into main-thread render code.
+
+```tsx
+function App() {
+  function handleTap() {
+    'background only';
+    lynx.getJSModule('Analytics').track('tap');
+  }
+
+  return <Button onClick={handleTap} />;
+}
+
+function Button({ onClick }) {
+  return <view bindtap={onClick}>Tap me</view>;
+}
+```
+
+### Background vs Main Thread Events
+
+Use normal `bind*`/`catch*` events for business logic, analytics, NativeModule calls, state updates, and network work. Use `main-thread:bind*` events for low-latency gesture or animation responses, and call `runOnBackground()` from the main thread when React state or background-only APIs are needed.

--- a/packages/skills/reactlynx-best-practices/src/auto-fix.ts
+++ b/packages/skills/reactlynx-best-practices/src/auto-fix.ts
@@ -5,6 +5,11 @@ import type { Diagnostic, Fix } from './types';
 
 export function generateFixes(source: string, diagnostic: Diagnostic): Fix[] {
   const fixes: Fix[] = [];
+
+  if (diagnostic.ruleId !== 'detect-background-only') {
+    return fixes;
+  }
+
   const lines = source.split('\n');
   const lineIndex = diagnostic.location.start.line - 1;
   const line = lines[lineIndex] || '';

--- a/packages/skills/reactlynx-best-practices/src/background-only.ts
+++ b/packages/skills/reactlynx-best-practices/src/background-only.ts
@@ -1,258 +1,271 @@
 // Copyright 2026 The Lynx Authors. All rights reserved.
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
-import { Lang, parse, type SgNode } from '@ast-grep/napi';
+import {
+  collectRegExpMatches,
+  createLineStarts,
+  findMatchingBracket,
+  isInsideAnyRange,
+  maskCommentsAndStrings,
+  positionAt,
+  type TextRange,
+} from './text-utils';
 import type { Diagnostic } from './types';
 
-const BACKGROUND_ONLY_DIRECTIVE = "'background only'";
-const BACKGROUND_ONLY_DIRECTIVE_DOUBLE = '"background only"';
+const BACKGROUND_ONLY_IMPORT_PATTERN =
+  /(?:^|\n)\s*import\s+['"]background-only['"]\s*;?/;
+const BACKGROUND_ONLY_DIRECTIVE_PATTERN = /^\s*['"]background only['"]\s*;?/;
+const EFFECT_CALL_PATTERN =
+  /\b(useEffect|useLayoutEffect|useImperativeHandle)\s*\(/g;
+const EVENT_ATTRIBUTE_PATTERN =
+  /(^|[\s<])((?:global-bind|global-catch|capture-bind|capture-catch|bind|catch)[A-Za-z0-9_-]*)\s*=\s*\{/g;
+const EVENT_ATTRIBUTE_STRING_PATTERN =
+  /(^|[\s<])((?:global-bind|global-catch|capture-bind|capture-catch|bind|catch)[A-Za-z0-9_-]*)\s*=\s*(['"])([A-Za-z_$][\w$]*)\3/g;
+const REF_ATTRIBUTE_PATTERN = /(^|[\s<])ref\s*=\s*\{/g;
+const FUNCTION_DECLARATION_PATTERN =
+  /\b(?:async\s+)?function(?:\s*\*)?\s*([A-Za-z_$][\w$]*)?\s*\([^)]*\)\s*\{/g;
+const VARIABLE_FUNCTION_PATTERN =
+  /\b(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*(?:async\s+)?function(?:\s*\*)?\s*(?:[A-Za-z_$][\w$]*)?\s*\([^)]*\)\s*\{/g;
+const VARIABLE_ARROW_FUNCTION_PATTERN =
+  /\b(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*(?:async\s*)?(?:\([^)]*\)|[A-Za-z_$][\w$]*)\s*=>\s*\{/g;
 
-const EVENT_HANDLER_ATTRS = ['bindtap', 'catchtap'];
+interface NamedRange extends TextRange {
+  name?: string;
+}
 
-function isBackgroundOnlyAPI(node: SgNode): {
-  isMatch: boolean;
+interface ApiMatch extends TextRange {
   apiName: string;
-} {
-  const text = node.text();
-
-  if (text.startsWith('lynx.getJSModule')) {
-    return { isMatch: true, apiName: 'lynx.getJSModule' };
-  }
-
-  if (text.startsWith('NativeModules')) {
-    return { isMatch: true, apiName: 'NativeModules' };
-  }
-
-  return { isMatch: false, apiName: '' };
 }
 
-function isInsideUseEffect(node: SgNode): boolean {
-  let current: SgNode | null = node;
-  while (current !== null) {
-    const parent: SgNode | null = current.parent();
-    if (parent === null) break;
-    current = parent;
-    if (current.kind() === 'call_expression') {
-      const callee = current.child(0);
-      if (callee) {
-        const text = callee.text();
-        if (
-          text === 'useEffect' ||
-          text === 'useLayoutEffect' ||
-          text === 'useImperativeHandle'
-        ) {
-          return true;
-        }
-      }
-    }
-  }
-  return false;
+function isBackgroundOnlyModule(source: string): boolean {
+  return BACKGROUND_ONLY_IMPORT_PATTERN.test(source);
 }
 
-function isInsideBackgroundOnlyFunction(node: SgNode): boolean {
-  let current: SgNode | null = node;
-  while (current !== null) {
-    const parent: SgNode | null = current.parent();
-    if (parent === null) break;
-    current = parent;
-    const kind = current.kind();
-    if (
-      kind === 'function_declaration' ||
-      kind === 'arrow_function' ||
-      kind === 'function_expression'
-    ) {
-      const body = current
-        .children()
-        .find((c: SgNode) => c.kind() === 'statement_block');
-      if (body) {
-        const firstStatement = body
-          .children()
-          .find((c: SgNode) => c.kind() === 'expression_statement');
-        if (firstStatement) {
-          const expr = firstStatement.child(0);
-          if (expr && expr.kind() === 'string') {
-            const text = expr.text();
-            if (
-              text === BACKGROUND_ONLY_DIRECTIVE ||
-              text === BACKGROUND_ONLY_DIRECTIVE_DOUBLE
-            ) {
-              return true;
-            }
-          }
-        }
-      }
-    }
-  }
-  return false;
-}
-
-function findEventHandlerFunctions(root: SgNode): Set<string> {
-  const handlerFunctions = new Set<string>();
-
-  const jsxAttributes = root.findAll({
-    rule: { kind: 'jsx_attribute' },
-  });
-
-  for (const attr of jsxAttributes) {
-    const nameNode = attr
-      .children()
-      .find((c: SgNode) => c.kind() === 'property_identifier');
-    if (!nameNode) continue;
-
-    const attrName = nameNode.text();
-    if (!EVENT_HANDLER_ATTRS.includes(attrName)) continue;
-
-    const valueNode = attr.children().find((c: SgNode) => {
-      const kind = c.kind();
-      return (
-        kind === 'jsx_expression' ||
-        kind === 'string' ||
-        kind === 'string_fragment'
-      );
-    });
-
-    if (valueNode) {
-      if (valueNode.kind() === 'jsx_expression') {
-        const inner = valueNode.child(1);
-        if (inner && inner.kind() === 'identifier') {
-          handlerFunctions.add(inner.text());
-        }
-      } else {
-        const text = valueNode.text().replace(/['"]/g, '');
-        if (text) {
-          handlerFunctions.add(text);
-        }
-      }
-    }
-  }
-
-  return handlerFunctions;
-}
-
-function isInsideEventHandler(
-  node: SgNode,
-  eventHandlerFunctions: Set<string>,
+function hasBackgroundOnlyDirective(
+  source: string,
+  bodyRange: TextRange,
 ): boolean {
-  let current: SgNode | null = node;
-  while (current !== null) {
-    const parent: SgNode | null = current.parent();
-    if (parent === null) break;
-    current = parent;
-    const kind = current.kind();
-
-    if (kind === 'function_declaration') {
-      const nameNode = current
-        .children()
-        .find((c: SgNode) => c.kind() === 'identifier');
-      if (nameNode && eventHandlerFunctions.has(nameNode.text())) {
-        return true;
-      }
-    }
-
-    if (kind === 'arrow_function' || kind === 'function_expression') {
-      const varParent = current.parent();
-      if (varParent && varParent.kind() === 'variable_declarator') {
-        const varName = varParent
-          .children()
-          .find((c: SgNode) => c.kind() === 'identifier');
-        if (varName && eventHandlerFunctions.has(varName.text())) {
-          return true;
-        }
-      }
-    }
-  }
-  return false;
+  return BACKGROUND_ONLY_DIRECTIVE_PATTERN.test(
+    source.slice(bodyRange.start, bodyRange.end),
+  );
 }
 
-function isInlineEventHandler(node: SgNode): boolean {
-  let current: SgNode | null = node;
-  while (current !== null) {
-    const parent: SgNode | null = current.parent();
-    if (parent === null) break;
-    current = parent;
+function collectFunctionRanges(source: string, masked: string): NamedRange[] {
+  const ranges: NamedRange[] = [];
 
-    if (current.kind() === 'jsx_expression') {
-      const jsxAttr = current.parent();
-      if (jsxAttr && jsxAttr.kind() === 'jsx_attribute') {
-        const nameNode = jsxAttr
-          .children()
-          .find((c: SgNode) => c.kind() === 'property_identifier');
-        if (nameNode && EVENT_HANDLER_ATTRS.includes(nameNode.text())) {
-          return true;
-        }
-      }
-    }
-  }
-  return false;
+  collectMatchedFunctionRanges(
+    source,
+    masked,
+    FUNCTION_DECLARATION_PATTERN,
+    ranges,
+  );
+  collectMatchedFunctionRanges(
+    source,
+    masked,
+    VARIABLE_FUNCTION_PATTERN,
+    ranges,
+  );
+  collectMatchedFunctionRanges(
+    source,
+    masked,
+    VARIABLE_ARROW_FUNCTION_PATTERN,
+    ranges,
+  );
+
+  return ranges;
 }
 
-function isInsideRefCallback(node: SgNode): boolean {
-  let current: SgNode | null = node;
-  while (current !== null) {
-    const parent: SgNode | null = current.parent();
-    if (parent === null) break;
-    current = parent;
+function collectMatchedFunctionRanges(
+  source: string,
+  masked: string,
+  pattern: RegExp,
+  ranges: NamedRange[],
+): void {
+  pattern.lastIndex = 0;
 
-    if (current.kind() === 'jsx_expression') {
-      const jsxAttr = current.parent();
-      if (jsxAttr && jsxAttr.kind() === 'jsx_attribute') {
-        const nameNode = jsxAttr
-          .children()
-          .find((c: SgNode) => c.kind() === 'property_identifier');
-        if (nameNode && nameNode.text() === 'ref') {
-          return true;
-        }
-      }
+  for (const match of collectRegExpMatches(pattern, masked)) {
+    const openBrace = masked.indexOf('{', match.index);
+    if (openBrace === -1) continue;
+
+    const closeBrace = findMatchingBracket(source, openBrace, '{', '}');
+    if (closeBrace === -1) continue;
+
+    ranges.push({
+      name: match[1],
+      start: openBrace,
+      end: closeBrace + 1,
+    });
+  }
+}
+
+function collectDirectiveRanges(
+  source: string,
+  functionRanges: NamedRange[],
+): TextRange[] {
+  return functionRanges.filter((range) =>
+    hasBackgroundOnlyDirective(source, {
+      start: range.start + 1,
+      end: range.end - 1,
+    }),
+  );
+}
+
+function collectEffectCallRanges(source: string, masked: string): TextRange[] {
+  const ranges: TextRange[] = [];
+  EFFECT_CALL_PATTERN.lastIndex = 0;
+
+  for (const match of collectRegExpMatches(EFFECT_CALL_PATTERN, masked)) {
+    const openParen = masked.indexOf('(', match.index);
+    if (openParen === -1) continue;
+
+    const closeParen = findMatchingBracket(source, openParen, '(', ')');
+    if (closeParen === -1) continue;
+
+    ranges.push({ start: openParen, end: closeParen + 1 });
+  }
+
+  return ranges;
+}
+
+function collectEventHandlerNames(
+  source: string,
+  masked: string,
+): { names: Set<string>; inlineRanges: TextRange[] } {
+  const names = new Set<string>();
+  const inlineRanges: TextRange[] = [];
+  EVENT_ATTRIBUTE_PATTERN.lastIndex = 0;
+
+  for (const match of collectRegExpMatches(EVENT_ATTRIBUTE_PATTERN, masked)) {
+    const openBrace = masked.indexOf('{', match.index);
+    if (openBrace === -1) continue;
+
+    const closeBrace = findMatchingBracket(source, openBrace, '{', '}');
+    if (closeBrace === -1) continue;
+
+    const expression = source.slice(openBrace + 1, closeBrace).trim();
+    if (/^[A-Za-z_$][\w$]*$/.test(expression)) {
+      names.add(expression);
+    }
+
+    inlineRanges.push({ start: openBrace, end: closeBrace + 1 });
+  }
+
+  EVENT_ATTRIBUTE_STRING_PATTERN.lastIndex = 0;
+  for (const match of collectRegExpMatches(
+    EVENT_ATTRIBUTE_STRING_PATTERN,
+    source,
+  )) {
+    const handlerName = match[4];
+    if (handlerName) {
+      names.add(handlerName);
     }
   }
-  return false;
+
+  return { names, inlineRanges };
+}
+
+function collectRefCallbackRanges(source: string, masked: string): TextRange[] {
+  const ranges: TextRange[] = [];
+  REF_ATTRIBUTE_PATTERN.lastIndex = 0;
+
+  for (const match of collectRegExpMatches(REF_ATTRIBUTE_PATTERN, masked)) {
+    const openBrace = masked.indexOf('{', match.index);
+    if (openBrace === -1) continue;
+
+    const closeBrace = findMatchingBracket(source, openBrace, '{', '}');
+    if (closeBrace === -1) continue;
+
+    ranges.push({ start: openBrace, end: closeBrace + 1 });
+  }
+
+  return ranges;
+}
+
+function collectNamedRanges(
+  names: Set<string>,
+  functionRanges: NamedRange[],
+): TextRange[] {
+  return functionRanges.filter((range) => {
+    return range.name !== undefined && names.has(range.name);
+  });
+}
+
+function collectApiMatches(masked: string): ApiMatch[] {
+  const matches: ApiMatch[] = [];
+
+  collectMatchesForApi(
+    masked,
+    /\blynx\s*\.\s*getJSModule\b/g,
+    'lynx.getJSModule',
+    matches,
+  );
+  collectMatchesForApi(masked, /\bNativeModules\b/g, 'NativeModules', matches);
+
+  return matches.sort((a, b) => a.start - b.start);
+}
+
+function collectMatchesForApi(
+  masked: string,
+  pattern: RegExp,
+  apiName: string,
+  matches: ApiMatch[],
+): void {
+  pattern.lastIndex = 0;
+
+  for (const match of collectRegExpMatches(pattern, masked)) {
+    matches.push({
+      apiName,
+      start: match.index,
+      end: match.index + match[0].length,
+    });
+  }
+}
+
+function isAllowedBackgroundContext(
+  apiIndex: number,
+  allowedRanges: TextRange[],
+): boolean {
+  return isInsideAnyRange(apiIndex, allowedRanges);
 }
 
 export function analyzeBackgroundOnlyUsage(source: string): Diagnostic[] {
+  if (isBackgroundOnlyModule(source)) {
+    return [];
+  }
+
   const diagnostics: Diagnostic[] = [];
-  const ast = parse(Lang.Tsx, source);
-  const root = ast.root();
+  const masked = maskCommentsAndStrings(source);
+  const lineStarts = createLineStarts(source);
+  const functionRanges = collectFunctionRanges(source, masked);
+  const directiveRanges = collectDirectiveRanges(source, functionRanges);
+  const effectRanges = collectEffectCallRanges(source, masked);
+  const { names: eventHandlerNames, inlineRanges: inlineEventRanges } =
+    collectEventHandlerNames(source, masked);
+  const eventHandlerRanges = collectNamedRanges(
+    eventHandlerNames,
+    functionRanges,
+  );
+  const refCallbackRanges = collectRefCallbackRanges(source, masked);
+  const allowedRanges = [
+    ...directiveRanges,
+    ...effectRanges,
+    ...inlineEventRanges,
+    ...eventHandlerRanges,
+    ...refCallbackRanges,
+  ];
 
-  const eventHandlerFunctions = findEventHandlerFunctions(root);
-
-  const memberExpressions = root.findAll({
-    rule: { kind: 'member_expression' },
-  });
-
-  const callExpressions = root.findAll({
-    rule: { kind: 'call_expression' },
-  });
-
-  const allNodes = [...memberExpressions, ...callExpressions];
-
-  const processedRanges = new Set<string>();
-
-  for (const node of allNodes) {
-    const { isMatch, apiName } = isBackgroundOnlyAPI(node);
-    if (!isMatch) continue;
-
-    const range = node.range();
-    const rangeKey = `${range.start.line}:${range.start.column}`;
-    if (processedRanges.has(rangeKey)) continue;
-    processedRanges.add(rangeKey);
-
-    if (isInsideUseEffect(node)) continue;
-
-    if (isInsideBackgroundOnlyFunction(node)) continue;
-
-    if (isInsideEventHandler(node, eventHandlerFunctions)) continue;
-
-    if (isInlineEventHandler(node)) continue;
-
-    if (isInsideRefCallback(node)) continue;
+  for (const match of collectApiMatches(masked)) {
+    if (isAllowedBackgroundContext(match.start, allowedRanges)) {
+      continue;
+    }
 
     diagnostics.push({
       ruleId: 'detect-background-only',
-      message: `'${apiName}' must only be called in background-only contexts (useEffect, useImperativeHandle, ref callback, 'background only' functions, or event handlers).`,
+      message: `'${match.apiName}' must only be called in background-only contexts (useEffect, useImperativeHandle, ref callback, 'background only' functions, event handlers, or modules marked with import 'background-only').`,
       severity: 'error',
       location: {
-        start: { line: range.start.line + 1, column: range.start.column },
-        end: { line: range.end.line + 1, column: range.end.column },
+        start: positionAt(match.start, lineStarts),
+        end: positionAt(match.end, lineStarts),
       },
     });
   }

--- a/packages/skills/reactlynx-best-practices/src/index.ts
+++ b/packages/skills/reactlynx-best-practices/src/index.ts
@@ -1,12 +1,13 @@
 // Copyright 2026 The Lynx Authors. All rights reserved.
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
-import { analyzeBackgroundOnlyUsage } from './background-only';
 import { analyzeSource } from './scanner';
 
 export { applyFix, applyFixes, generateFixes } from './auto-fix';
 
 export { analyzeBackgroundOnlyUsage } from './background-only';
+
+export { analyzeLifecycleUsage } from './lifecycle';
 
 export {
   analyzeSource,
@@ -36,7 +37,7 @@ export {
 } from './workflow';
 
 export function runSkill(source: string) {
-  return analyzeBackgroundOnlyUsage(source);
+  return analyzeSource(source);
 }
 
 export function runSkillWithFixes(source: string) {
@@ -49,5 +50,40 @@ export const rules = {
     severity: 'error' as const,
     message:
       'lynx.getJSModule and NativeModules must only be called in background-only contexts.',
+  },
+  'avoid-use-layout-effect': {
+    id: 'avoid-use-layout-effect',
+    severity: 'warning' as const,
+    message:
+      'ReactLynx does not support useLayoutEffect; use useEffect or main-thread layout events instead.',
+  },
+  'proper-event-handlers': {
+    id: 'proper-event-handlers',
+    severity: 'warning' as const,
+    message:
+      'Use ReactLynx event handlers with correct propagation, thread context, and custom prop boundaries.',
+  },
+  'main-thread-scripts-guide': {
+    id: 'main-thread-scripts-guide',
+    severity: 'warning' as const,
+    message:
+      'Use main thread scripts only for low-latency UI work and respect MTS restrictions.',
+  },
+  'code-splitting': {
+    id: 'code-splitting',
+    severity: 'info' as const,
+    message:
+      'Use lazy loading, Suspense, and CSS bundle-scope awareness for split ReactLynx code.',
+  },
+  'performance-profiling': {
+    id: 'performance-profiling',
+    severity: 'info' as const,
+    message:
+      'Use ReactLynx profiling traces, flow IDs, and displayName values to optimize hot paths.',
+  },
+  'hoist-static-jsx': {
+    id: 'hoist-static-jsx',
+    severity: 'info' as const,
+    message: 'Hoist large static JSX when React Compiler is not handling it.',
   },
 };

--- a/packages/skills/reactlynx-best-practices/src/lifecycle.ts
+++ b/packages/skills/reactlynx-best-practices/src/lifecycle.ts
@@ -1,0 +1,35 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import {
+  collectRegExpMatches,
+  createLineStarts,
+  maskCommentsAndStrings,
+  positionAt,
+} from './text-utils';
+import type { Diagnostic } from './types';
+
+const USE_LAYOUT_EFFECT_PATTERN = /\buseLayoutEffect\s*\(/g;
+
+export function analyzeLifecycleUsage(source: string): Diagnostic[] {
+  const diagnostics: Diagnostic[] = [];
+  const masked = maskCommentsAndStrings(source);
+  const lineStarts = createLineStarts(source);
+
+  USE_LAYOUT_EFFECT_PATTERN.lastIndex = 0;
+
+  for (const match of collectRegExpMatches(USE_LAYOUT_EFFECT_PATTERN, masked)) {
+    diagnostics.push({
+      ruleId: 'avoid-use-layout-effect',
+      message:
+        'ReactLynx does not support useLayoutEffect; use useEffect for background side effects or main-thread:bindlayoutchange/main-thread:ref for layout reads.',
+      severity: 'warning',
+      location: {
+        start: positionAt(match.index, lineStarts),
+        end: positionAt(match.index + 'useLayoutEffect'.length, lineStarts),
+      },
+    });
+  }
+
+  return diagnostics;
+}

--- a/packages/skills/reactlynx-best-practices/src/scanner.ts
+++ b/packages/skills/reactlynx-best-practices/src/scanner.ts
@@ -3,13 +3,17 @@
 // LICENSE file in the root directory of this source tree.
 import { generateFixes } from './auto-fix';
 import { analyzeBackgroundOnlyUsage } from './background-only';
+import { analyzeLifecycleUsage } from './lifecycle';
 import type { DiagnosticWithFix, ScanResult, ScanSummary } from './types';
 
 export function analyzeSource(
   source: string,
   options?: { generateFixes?: boolean },
 ): DiagnosticWithFix[] {
-  const diagnostics = analyzeBackgroundOnlyUsage(source);
+  const diagnostics = [
+    ...analyzeBackgroundOnlyUsage(source),
+    ...analyzeLifecycleUsage(source),
+  ];
 
   if (!options?.generateFixes) {
     return diagnostics;

--- a/packages/skills/reactlynx-best-practices/src/text-utils.ts
+++ b/packages/skills/reactlynx-best-practices/src/text-utils.ts
@@ -1,0 +1,215 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+export interface TextRange {
+  start: number;
+  end: number;
+}
+
+export function maskCommentsAndStrings(source: string): string {
+  const chars = source.split('');
+  let index = 0;
+
+  while (index < chars.length) {
+    const current = chars[index];
+    const next = chars[index + 1];
+
+    if (current === '/' && next === '/') {
+      chars[index] = ' ';
+      chars[index + 1] = ' ';
+      index += 2;
+      while (index < chars.length && chars[index] !== '\n') {
+        chars[index] = ' ';
+        index++;
+      }
+      continue;
+    }
+
+    if (current === '/' && next === '*') {
+      chars[index] = ' ';
+      chars[index + 1] = ' ';
+      index += 2;
+      while (index < chars.length) {
+        if (chars[index] === '*' && chars[index + 1] === '/') {
+          chars[index] = ' ';
+          chars[index + 1] = ' ';
+          index += 2;
+          break;
+        }
+        if (chars[index] !== '\n') {
+          chars[index] = ' ';
+        }
+        index++;
+      }
+      continue;
+    }
+
+    if (current === "'" || current === '"' || current === '`') {
+      const quote = current;
+      chars[index] = ' ';
+      index++;
+      while (index < chars.length) {
+        const char = chars[index];
+        if (char === '\\') {
+          chars[index] = ' ';
+          if (index + 1 < chars.length && chars[index + 1] !== '\n') {
+            chars[index + 1] = ' ';
+          }
+          index += 2;
+          continue;
+        }
+        if (char === quote) {
+          chars[index] = ' ';
+          index++;
+          break;
+        }
+        if (char !== '\n') {
+          chars[index] = ' ';
+        }
+        index++;
+      }
+      continue;
+    }
+
+    index++;
+  }
+
+  return chars.join('');
+}
+
+export function findMatchingBracket(
+  source: string,
+  openIndex: number,
+  openChar: string,
+  closeChar: string,
+): number {
+  let depth = 0;
+  let index = openIndex;
+  let quote: string | null = null;
+  let inLineComment = false;
+  let inBlockComment = false;
+
+  while (index < source.length) {
+    const current = source[index];
+    const next = source[index + 1];
+
+    if (inLineComment) {
+      if (current === '\n') {
+        inLineComment = false;
+      }
+      index++;
+      continue;
+    }
+
+    if (inBlockComment) {
+      if (current === '*' && next === '/') {
+        inBlockComment = false;
+        index += 2;
+        continue;
+      }
+      index++;
+      continue;
+    }
+
+    if (quote !== null) {
+      if (current === '\\') {
+        index += 2;
+        continue;
+      }
+      if (current === quote) {
+        quote = null;
+      }
+      index++;
+      continue;
+    }
+
+    if (current === '/' && next === '/') {
+      inLineComment = true;
+      index += 2;
+      continue;
+    }
+
+    if (current === '/' && next === '*') {
+      inBlockComment = true;
+      index += 2;
+      continue;
+    }
+
+    if (current === "'" || current === '"' || current === '`') {
+      quote = current;
+      index++;
+      continue;
+    }
+
+    if (current === openChar) {
+      depth++;
+    } else if (current === closeChar) {
+      depth--;
+      if (depth === 0) {
+        return index;
+      }
+    }
+
+    index++;
+  }
+
+  return -1;
+}
+
+export function createLineStarts(source: string): number[] {
+  const starts = [0];
+  for (let index = 0; index < source.length; index++) {
+    if (source[index] === '\n') {
+      starts.push(index + 1);
+    }
+  }
+  return starts;
+}
+
+export function positionAt(
+  index: number,
+  lineStarts: number[],
+): { line: number; column: number } {
+  let low = 0;
+  let high = lineStarts.length - 1;
+
+  while (low <= high) {
+    const middle = Math.floor((low + high) / 2);
+    const lineStart = lineStarts[middle] ?? 0;
+    const nextLineStart = lineStarts[middle + 1] ?? Number.POSITIVE_INFINITY;
+
+    if (index < lineStart) {
+      high = middle - 1;
+    } else if (index >= nextLineStart) {
+      low = middle + 1;
+    } else {
+      return { line: middle + 1, column: index - lineStart };
+    }
+  }
+
+  const fallbackStart = lineStarts[lineStarts.length - 1] ?? 0;
+  return {
+    line: lineStarts.length,
+    column: Math.max(0, index - fallbackStart),
+  };
+}
+
+export function isInsideAnyRange(index: number, ranges: TextRange[]): boolean {
+  return ranges.some((range) => index >= range.start && index < range.end);
+}
+
+export function collectRegExpMatches(
+  pattern: RegExp,
+  source: string,
+): RegExpExecArray[] {
+  const matches: RegExpExecArray[] = [];
+  pattern.lastIndex = 0;
+
+  let match = pattern.exec(source);
+  while (match !== null) {
+    matches.push(match);
+    match = pattern.exec(source);
+  }
+
+  return matches;
+}

--- a/packages/skills/reactlynx-best-practices/tests/detect-background-only.test.ts
+++ b/packages/skills/reactlynx-best-practices/tests/detect-background-only.test.ts
@@ -101,6 +101,18 @@ export function App() {
   });
 
   describe('should allow in background only functions', () => {
+    it('should allow entire modules marked with background-only import', () => {
+      const source = `
+import 'background-only';
+
+export function getEnv() {
+  return NativeModules.Env.get();
+}
+`;
+      const diagnostics = analyzeBackgroundOnlyUsage(source);
+      expect(diagnostics).toHaveLength(0);
+    });
+
     it('should allow lynx.getJSModule inside background only function', () => {
       const source = `
 export function App() {
@@ -194,6 +206,21 @@ export function App() {
 `;
       const diagnostics = analyzeBackgroundOnlyUsage(source);
       expect(diagnostics).toHaveLength(0);
+    });
+
+    it('should require background only directive for handlers passed through custom props', () => {
+      const source = `
+export function App() {
+  function handleTap() {
+    lynx.getJSModule('SomeModule');
+  }
+
+  return <Button onClick={handleTap} />;
+}
+`;
+      const diagnostics = analyzeBackgroundOnlyUsage(source);
+      expect(diagnostics).toHaveLength(1);
+      expect(diagnostics[0].message).toContain('lynx.getJSModule');
     });
   });
 

--- a/packages/skills/reactlynx-best-practices/tests/lifecycle.test.ts
+++ b/packages/skills/reactlynx-best-practices/tests/lifecycle.test.ts
@@ -1,0 +1,50 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { describe, expect, it } from '@rstest/core';
+import { analyzeLifecycleUsage, runSkill } from '../src/index';
+
+describe('avoid-use-layout-effect', () => {
+  it('should warn when useLayoutEffect is used', () => {
+    const source = `
+export function App() {
+  useLayoutEffect(() => {
+    console.log('measure');
+  }, []);
+  return <view />;
+}
+`;
+    const diagnostics = analyzeLifecycleUsage(source);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].ruleId).toBe('avoid-use-layout-effect');
+    expect(diagnostics[0].severity).toBe('warning');
+  });
+
+  it('should be included in runSkill diagnostics', () => {
+    const source = `
+export function App() {
+  useLayoutEffect(() => {}, []);
+  lynx.getJSModule('SomeModule');
+  return <view />;
+}
+`;
+    const diagnostics = runSkill(source);
+    expect(diagnostics.map((diagnostic) => diagnostic.ruleId)).toEqual([
+      'detect-background-only',
+      'avoid-use-layout-effect',
+    ]);
+  });
+
+  it('should not warn for useEffect', () => {
+    const source = `
+export function App() {
+  useEffect(() => {
+    console.log('side effect');
+  }, []);
+  return <view />;
+}
+`;
+    const diagnostics = analyzeLifecycleUsage(source);
+    expect(diagnostics).toHaveLength(0);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -193,10 +193,6 @@ importers:
   packages/skills/lynx-typescript: {}
 
   packages/skills/reactlynx-best-practices:
-    dependencies:
-      '@ast-grep/napi':
-        specifier: ^0.37.0
-        version: 0.37.0
     devDependencies:
       '@microsoft/api-extractor':
         specifier: ^7.56.2


### PR DESCRIPTION
## What changed

- Added a changeset for @lynx-js/skill-reactlynx-best-practices with a minor bump.
- Removed the skill package's direct runtime dependency on @ast-grep/napi.
- Reworked scanner coverage for background-only and lifecycle usage.
- Expanded ReactLynx best-practice guidance for dual-thread, lifecycle, MTS, code splitting, and profiling.

## Validation

- pnpm check
- pnpm --filter @lynx-js/skill-reactlynx-best-practices test
- pnpm --filter @lynx-js/skill-reactlynx-best-practices build