### PR TITLE
chore: use lynx-ui preview package

### DIFF
--- a/export-skills.mjs
+++ b/export-skills.mjs
@@ -2,10 +2,10 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 import { execSync, spawn } from 'node:child_process';
-import { readFileSync } from 'node:fs';
+import { readFileSync, writeFileSync } from 'node:fs';
 import { rm } from 'node:fs/promises';
 import { createRequire } from 'node:module';
-import { dirname, resolve } from 'node:path';
+import { dirname, join, resolve } from 'node:path';
 
 const require = createRequire(import.meta.url);
 
@@ -64,6 +64,24 @@ function runBuildPlugin(skillPath, targetDir) {
   });
 }
 
+/**
+ * @param {string} targetDir
+ * @returns {void}
+ */
+function normalizeSkillFrontmatter(targetDir) {
+  const skillMd = join(targetDir, 'SKILL.md');
+  const content = readFileSync(skillMd, 'utf-8');
+  const updated = content.replace(
+    /^description: ([^\n"'[{|>].*)$/m,
+    (_match, description) =>
+      `description: ${JSON.stringify(description.trim())}`,
+  );
+
+  if (updated !== content) {
+    writeFileSync(skillMd, updated);
+  }
+}
+
 const skillsOutputDir = resolve(process.cwd(), 'skills');
 await rm(skillsOutputDir, { recursive: true, force: true });
 
@@ -74,5 +92,6 @@ for (const skill of skills) {
     name.replace('@lynx-js/skill-', ''),
   );
   await runBuildPlugin(skillPath, targetDir);
+  normalizeSkillFrontmatter(targetDir);
   console.error(`Exported skill: ${name}`);
 }

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@lynx-js/skill-lynx-trace-analysis": "0.0.6",
     "@lynx-js/skill-lynx-trace-record": "0.0.3",
     "@lynx-js/skill-lynx-typescript": "workspace:*",
-    "@lynx-js/skill-lynx-ui": "3.133.3",
+    "@lynx-js/skill-lynx-ui": "https://pkg.pr.new/@lynx-js/skill-lynx-ui@9d867e5",
     "@lynx-js/skill-reactlynx-best-practices": "workspace:*"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@lynx-js/skill-lynx-trace-analysis": "0.0.6",
     "@lynx-js/skill-lynx-trace-record": "0.0.3",
     "@lynx-js/skill-lynx-typescript": "workspace:*",
-    "@lynx-js/skill-lynx-ui": "3.133.2",
+    "@lynx-js/skill-lynx-ui": "3.133.3",
     "@lynx-js/skill-reactlynx-best-practices": "workspace:*"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,8 +45,8 @@ importers:
         specifier: workspace:*
         version: link:packages/skills/lynx-typescript
       '@lynx-js/skill-lynx-ui':
-        specifier: 3.133.2
-        version: 3.133.2
+        specifier: 3.133.3
+        version: 3.133.3
       '@lynx-js/skill-reactlynx-best-practices':
         specifier: workspace:*
         version: link:packages/skills/reactlynx-best-practices
@@ -685,8 +685,8 @@ packages:
     resolution: {integrity: sha512-gQINVVX4c0OO8wxKLI30jfaLrWY1nRfDQpPipzjYXAVEGRJ0BQ+KwWj76MthK4f9D+LOj6Y8mG31yI+YmGpc4w==}
     engines: {node: '>=18'}
 
-  '@lynx-js/skill-lynx-ui@3.133.2':
-    resolution: {integrity: sha512-IGUDHPRMltXEmft4LNpfXY938E0rRQtVfSbFltmj4TAEZV3LI8TzSPqJ/XytuISnEmRqHmxYhEQz8lNH3CXu3g==}
+  '@lynx-js/skill-lynx-ui@3.133.3':
+    resolution: {integrity: sha512-wz6rHhOUiXHVMAidZCPdy3fQWT7qczv8LKeIlmOitL5+jLTF7skgVoUrZDAWRubcIy0OYtr4bCn8oeONfMZvwg==}
 
   '@manypkg/find-root@1.1.0':
     resolution: {integrity: sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==}
@@ -2335,7 +2335,7 @@ snapshots:
 
   '@lynx-js/skill-lynx-trace-record@0.0.3': {}
 
-  '@lynx-js/skill-lynx-ui@3.133.2': {}
+  '@lynx-js/skill-lynx-ui@3.133.3': {}
 
   '@manypkg/find-root@1.1.0':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,8 +45,8 @@ importers:
         specifier: workspace:*
         version: link:packages/skills/lynx-typescript
       '@lynx-js/skill-lynx-ui':
-        specifier: 3.133.3
-        version: 3.133.3
+        specifier: https://pkg.pr.new/@lynx-js/skill-lynx-ui@9d867e5
+        version: https://pkg.pr.new/@lynx-js/skill-lynx-ui@9d867e5
       '@lynx-js/skill-reactlynx-best-practices':
         specifier: workspace:*
         version: link:packages/skills/reactlynx-best-practices
@@ -685,8 +685,9 @@ packages:
     resolution: {integrity: sha512-gQINVVX4c0OO8wxKLI30jfaLrWY1nRfDQpPipzjYXAVEGRJ0BQ+KwWj76MthK4f9D+LOj6Y8mG31yI+YmGpc4w==}
     engines: {node: '>=18'}
 
-  '@lynx-js/skill-lynx-ui@3.133.3':
-    resolution: {integrity: sha512-wz6rHhOUiXHVMAidZCPdy3fQWT7qczv8LKeIlmOitL5+jLTF7skgVoUrZDAWRubcIy0OYtr4bCn8oeONfMZvwg==}
+  '@lynx-js/skill-lynx-ui@https://pkg.pr.new/@lynx-js/skill-lynx-ui@9d867e5':
+    resolution: {tarball: https://pkg.pr.new/@lynx-js/skill-lynx-ui@9d867e5}
+    version: 3.133.3
 
   '@manypkg/find-root@1.1.0':
     resolution: {integrity: sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==}
@@ -1798,6 +1799,7 @@ packages:
   tar@7.5.7:
     resolution: {integrity: sha512-fov56fJiRuThVFXD6o6/Q354S7pnWMJIVlDBYijsTNx6jKSE4pvrDTs6lUnmGvNyfJwFQQwWy3owKz1ucIhveQ==}
     engines: {node: '>=18'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   term-size@2.2.1:
     resolution: {integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==}
@@ -2335,7 +2337,7 @@ snapshots:
 
   '@lynx-js/skill-lynx-trace-record@0.0.3': {}
 
-  '@lynx-js/skill-lynx-ui@3.133.3': {}
+  '@lynx-js/skill-lynx-ui@https://pkg.pr.new/@lynx-js/skill-lynx-ui@9d867e5': {}
 
   '@manypkg/find-root@1.1.0':
     dependencies:


### PR DESCRIPTION
## Summary
- update @lynx-js/skill-lynx-ui to use the pkg.pr.new preview package at 9d867e5
- refresh pnpm-lock.yaml with the preview tarball resolution
- quote exported single-line skill descriptions so generated SKILL.md front matter remains valid YAML

## Validation
- pnpm add -w --store-dir /Users/wangyang/Library/pnpm/store/v10 https://pkg.pr.new/@lynx-js/skill-lynx-ui@9d867e5
- pnpm build
- node --test scripts/validate-skills.test.mjs
- pnpm check