### PR TITLE
ci: skip online evals for fork pull requests

### DIFF
--- a/.github/actions/evals-comment/comment.mjs
+++ b/.github/actions/evals-comment/comment.mjs
@@ -117,9 +117,17 @@ function normalizeReport(payload) {
     payload && typeof payload.task_error === 'string'
       ? payload.task_error.trim()
       : '';
+  const taskSkip =
+    payload && typeof payload.task_skip === 'string'
+      ? payload.task_skip.trim()
+      : '';
   const triggerError =
     payload && typeof payload.trigger_error === 'string'
       ? payload.trigger_error.trim()
+      : '';
+  const triggerSkip =
+    payload && typeof payload.trigger_skip === 'string'
+      ? payload.trigger_skip.trim()
       : '';
   const reports = normalizeReportList(payload);
   const rows = new Map();
@@ -170,8 +178,10 @@ function normalizeReport(payload) {
     definitionSummary,
     results,
     taskError,
+    taskSkip,
     taskSummary: buildTaskSummary(results),
     triggerError,
+    triggerSkip,
     triggerSummary: buildTriggerSummary(results),
   };
 }
@@ -367,6 +377,8 @@ function formatComment({ marker, report, title }) {
     lines.push(
       `Task eval score: failed before producing online task reports. ${escapeMarkdown(report.taskError)}`,
     );
+  } else if (report.taskSkip) {
+    lines.push(`Task eval score: skipped. ${escapeMarkdown(report.taskSkip)}`);
   } else {
     lines.push(
       'Task eval score: not run in this report. Online task reports will fill `with_skill`, `without_skill`, and Δ.',
@@ -385,6 +397,10 @@ function formatComment({ marker, report, title }) {
   } else if (report.triggerError) {
     lines.push(
       `Trigger eval score: failed before producing online trigger reports. ${escapeMarkdown(report.triggerError)}`,
+    );
+  } else if (report.triggerSkip) {
+    lines.push(
+      `Trigger eval score: skipped. ${escapeMarkdown(report.triggerSkip)}`,
     );
   }
 

--- a/.github/workflows/evals-comment.yml
+++ b/.github/workflows/evals-comment.yml
@@ -42,7 +42,17 @@ jobs:
           pnpm eval:skill:check:all -- \
             --json-output artifacts/skill-evals-definition.json
 
+      - name: Note skipped online evals for forked pull requests
+        if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
+        run: |
+          mkdir -p artifacts
+          MESSAGE="Skipped for forked pull request because Ark credentials are unavailable to pull_request workflows from forks."
+          printf '%s\n' "$MESSAGE" > artifacts/skill-evals-task-skip.txt
+          printf '%s\n' "$MESSAGE" > artifacts/skill-evals-trigger-skip.txt
+          echo "::notice::$MESSAGE"
+
       - name: Run online skill task evals
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
         id: task-evals
         continue-on-error: true
         env:
@@ -106,6 +116,7 @@ jobs:
           exit "$TASK_EXIT"
 
       - name: Run online skill trigger evals
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
         id: trigger-evals
         continue-on-error: true
         env:
@@ -162,7 +173,9 @@ jobs:
           pnpm eval:skill:comment-report -- \
             --definition-report artifacts/skill-evals-definition.json \
             --task-error-file artifacts/skill-evals-task-error.txt \
+            --task-skip-file artifacts/skill-evals-task-skip.txt \
             --trigger-error-file artifacts/skill-evals-trigger-error.txt \
+            --trigger-skip-file artifacts/skill-evals-trigger-skip.txt \
             --task-report-dir artifacts \
             --output artifacts/skill-evals-comment.json
 
@@ -195,9 +208,9 @@ jobs:
         run: exit 1
 
       - name: Fail on online task eval failures
-        if: steps.task-evals.outcome != 'success'
+        if: steps.task-evals.outcome == 'failure'
         run: exit 1
 
       - name: Fail on online trigger eval failures
-        if: steps.trigger-evals.outcome != 'success'
+        if: steps.trigger-evals.outcome == 'failure'
         run: exit 1

--- a/scripts/skill-eval/build_comment_report.mjs
+++ b/scripts/skill-eval/build_comment_report.mjs
@@ -21,8 +21,14 @@ async function main() {
   const taskErrorFile = args.taskErrorFile
     ? resolve(args.taskErrorFile)
     : undefined;
+  const taskSkipFile = args.taskSkipFile
+    ? resolve(args.taskSkipFile)
+    : undefined;
   const triggerErrorFile = args.triggerErrorFile
     ? resolve(args.triggerErrorFile)
+    : undefined;
+  const triggerSkipFile = args.triggerSkipFile
+    ? resolve(args.triggerSkipFile)
     : undefined;
 
   const definitionReport = await readJson(definitionReportPath);
@@ -40,9 +46,17 @@ async function main() {
       taskErrorFile && existsSync(taskErrorFile)
         ? (await readFile(taskErrorFile, 'utf8')).trim()
         : undefined,
+    task_skip:
+      taskSkipFile && existsSync(taskSkipFile)
+        ? (await readFile(taskSkipFile, 'utf8')).trim()
+        : undefined,
     trigger_error:
       triggerErrorFile && existsSync(triggerErrorFile)
         ? (await readFile(triggerErrorFile, 'utf8')).trim()
+        : undefined,
+    trigger_skip:
+      triggerSkipFile && existsSync(triggerSkipFile)
+        ? (await readFile(triggerSkipFile, 'utf8')).trim()
         : undefined,
   };
   await mkdir(dirname(outputPath), { recursive: true });
@@ -70,8 +84,16 @@ function parseArgs(argv) {
       args.taskErrorFile = argv[++index];
       continue;
     }
+    if (arg === '--task-skip-file') {
+      args.taskSkipFile = argv[++index];
+      continue;
+    }
     if (arg === '--trigger-error-file') {
       args.triggerErrorFile = argv[++index];
+      continue;
+    }
+    if (arg === '--trigger-skip-file') {
+      args.triggerSkipFile = argv[++index];
       continue;
     }
     if (arg === '--output') {


### PR DESCRIPTION
## Summary

- Skip Ark-backed online task and trigger eval steps for forked `pull_request` runs, where repository credentials are unavailable.
- Preserve skill eval definition checks for fork PRs and add a clear skipped message to the eval report/summary.
- Keep online evals required for same-repository PRs, `push` to `main`, and manual workflow runs by only failing when the online eval step actually fails.

## Validation

- `pnpm exec biome check .github/workflows/evals-comment.yml scripts/skill-eval/build_comment_report.mjs .github/actions/evals-comment/comment.mjs`
- Simulated fork skip report with `pnpm eval:skill:check:all`, `pnpm eval:skill:comment-report`, and `.github/actions/evals-comment/comment.mjs`
- `pnpm check`
- `pnpm test`
