### PR TITLE
fix: prefer packaged skill evals

### DIFF
--- a/scripts/skill-eval/check_evals.mjs
+++ b/scripts/skill-eval/check_evals.mjs
@@ -2,10 +2,9 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 import { existsSync } from 'node:fs';
-import { mkdir, readdir, readFile, writeFile } from 'node:fs/promises';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { basename, join, resolve } from 'node:path';
-
-const SKILL_PACKAGE_PREFIX = '@lynx-js/skill-';
+import { discoverSkillSuites } from './discover_suites.mjs';
 
 main().catch((error) => {
   console.error(error instanceof Error ? error.message : String(error));
@@ -81,79 +80,6 @@ function parseArgs(argv) {
     throw new Error(`Unknown argument: ${arg}`);
   }
   return args;
-}
-
-async function discoverSkillSuites(repoRoot) {
-  const skillsRoot = join(repoRoot, 'packages/skills');
-  if (!existsSync(skillsRoot)) {
-    throw new Error(`skills directory not found: ${skillsRoot}`);
-  }
-
-  const entries = await readdir(skillsRoot, { withFileTypes: true });
-  const sourceSuites = entries
-    .filter((entry) => entry.isDirectory())
-    .map((entry) => {
-      const skillPath = join(skillsRoot, entry.name);
-      return {
-        packageName: undefined,
-        evalPath: join(skillPath, 'evals'),
-        skillPath,
-      };
-    })
-    .filter((suite) => existsSync(join(suite.skillPath, 'SKILL.md')))
-    .sort((left, right) => left.skillPath.localeCompare(right.skillPath));
-
-  const sourcePackages = await getSourcePackageMap(sourceSuites);
-  const suitesBySkillPath = new Map(
-    sourceSuites.map((suite) => [suite.skillPath, suite]),
-  );
-
-  for (const dependencyName of await getSkillDependencies(repoRoot)) {
-    const sourceSuite = sourcePackages.get(dependencyName);
-    if (sourceSuite) {
-      sourceSuite.packageName = dependencyName;
-      continue;
-    }
-
-    const skillSlug = dependencyName.slice(SKILL_PACKAGE_PREFIX.length);
-    const skillPath = join(
-      repoRoot,
-      'node_modules',
-      ...dependencyName.split('/'),
-    );
-    suitesBySkillPath.set(skillPath, {
-      packageName: dependencyName,
-      evalPath: join(repoRoot, 'evals', skillSlug),
-      skillPath,
-    });
-  }
-
-  return Array.from(suitesBySkillPath.values()).sort((left, right) =>
-    String(left.packageName ?? left.skillPath).localeCompare(
-      String(right.packageName ?? right.skillPath),
-    ),
-  );
-}
-
-async function getSourcePackageMap(sourceSuites) {
-  const packages = new Map();
-  for (const suite of sourceSuites) {
-    const packageJsonPath = join(suite.skillPath, 'package.json');
-    if (!existsSync(packageJsonPath)) continue;
-    const packageJson = await readJson(packageJsonPath);
-    if (typeof packageJson.name === 'string') {
-      packages.set(packageJson.name, suite);
-    }
-  }
-  return packages;
-}
-
-async function getSkillDependencies(repoRoot) {
-  const packageJson = await readJson(join(repoRoot, 'package.json'));
-  const dependencies = packageJson.dependencies ?? {};
-  return Object.keys(dependencies)
-    .filter((name) => name.startsWith(SKILL_PACKAGE_PREFIX))
-    .sort();
 }
 
 function buildSingleSuite(args) {

--- a/scripts/skill-eval/discover_suites.mjs
+++ b/scripts/skill-eval/discover_suites.mjs
@@ -1,0 +1,95 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { existsSync } from 'node:fs';
+import { readdir, readFile } from 'node:fs/promises';
+import { basename, join } from 'node:path';
+
+const SKILL_PACKAGE_PREFIX = '@lynx-js/skill-';
+
+export async function discoverSkillSuites(repoRoot) {
+  const skillsRoot = join(repoRoot, 'packages/skills');
+  if (!existsSync(skillsRoot)) {
+    throw new Error(`skills directory not found: ${skillsRoot}`);
+  }
+
+  const entries = await readdir(skillsRoot, { withFileTypes: true });
+  const sourceSuites = entries
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => {
+      const skillPath = join(skillsRoot, entry.name);
+      return {
+        evalPath: join(skillPath, 'evals'),
+        packageName: undefined,
+        skillPath,
+      };
+    })
+    .filter((suite) => existsSync(join(suite.skillPath, 'SKILL.md')))
+    .sort((left, right) => left.skillPath.localeCompare(right.skillPath));
+
+  const sourcePackages = await getSourcePackageMap(sourceSuites);
+  const suitesBySkillPath = new Map(
+    sourceSuites.map((suite) => [suite.skillPath, suite]),
+  );
+
+  for (const dependencyName of await getSkillDependencies(repoRoot)) {
+    const sourceSuite = sourcePackages.get(dependencyName);
+    if (sourceSuite) {
+      sourceSuite.packageName = dependencyName;
+      continue;
+    }
+
+    const skillSlug = dependencyName.slice(SKILL_PACKAGE_PREFIX.length);
+    const skillPath = join(
+      repoRoot,
+      'node_modules',
+      ...dependencyName.split('/'),
+    );
+    const packageEvalPath = join(skillPath, 'evals');
+    suitesBySkillPath.set(skillPath, {
+      evalPath: existsSync(packageEvalPath)
+        ? packageEvalPath
+        : join(repoRoot, 'evals', skillSlug),
+      packageName: dependencyName,
+      skillPath,
+    });
+  }
+
+  return Array.from(suitesBySkillPath.values()).sort((left, right) =>
+    String(left.packageName ?? left.skillPath).localeCompare(
+      String(right.packageName ?? right.skillPath),
+    ),
+  );
+}
+
+export function suiteSlug(suite) {
+  if (suite.packageName?.startsWith(SKILL_PACKAGE_PREFIX)) {
+    return suite.packageName.slice(SKILL_PACKAGE_PREFIX.length);
+  }
+  return basename(suite.skillPath);
+}
+
+async function getSourcePackageMap(sourceSuites) {
+  const packages = new Map();
+  for (const suite of sourceSuites) {
+    const packageJsonPath = join(suite.skillPath, 'package.json');
+    if (!existsSync(packageJsonPath)) continue;
+    const packageJson = await readJson(packageJsonPath);
+    if (typeof packageJson.name === 'string') {
+      packages.set(packageJson.name, suite);
+    }
+  }
+  return packages;
+}
+
+async function getSkillDependencies(repoRoot) {
+  const packageJson = await readJson(join(repoRoot, 'package.json'));
+  const dependencies = packageJson.dependencies ?? {};
+  return Object.keys(dependencies)
+    .filter((name) => name.startsWith(SKILL_PACKAGE_PREFIX))
+    .sort();
+}
+
+async function readJson(path) {
+  return JSON.parse(await readFile(path, 'utf8'));
+}

--- a/scripts/skill-eval/run_task_online_all.mjs
+++ b/scripts/skill-eval/run_task_online_all.mjs
@@ -2,11 +2,9 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 import { spawn } from 'node:child_process';
-import { existsSync } from 'node:fs';
-import { readdir, readFile } from 'node:fs/promises';
-import { basename, join, resolve } from 'node:path';
-
-const SKILL_PACKAGE_PREFIX = '@lynx-js/skill-';
+import { readFile } from 'node:fs/promises';
+import { join, resolve } from 'node:path';
+import { discoverSkillSuites, suiteSlug } from './discover_suites.mjs';
 
 main().catch((error) => {
   console.error(error instanceof Error ? error.message : String(error));
@@ -106,79 +104,6 @@ function parseArgs(argv) {
   return args;
 }
 
-async function discoverSkillSuites(repoRoot) {
-  const skillsRoot = join(repoRoot, 'packages/skills');
-  if (!existsSync(skillsRoot)) {
-    throw new Error(`skills directory not found: ${skillsRoot}`);
-  }
-
-  const entries = await readdir(skillsRoot, { withFileTypes: true });
-  const sourceSuites = entries
-    .filter((entry) => entry.isDirectory())
-    .map((entry) => {
-      const skillPath = join(skillsRoot, entry.name);
-      return {
-        evalPath: join(skillPath, 'evals'),
-        packageName: undefined,
-        skillPath,
-      };
-    })
-    .filter((suite) => existsSync(join(suite.skillPath, 'SKILL.md')))
-    .sort((left, right) => left.skillPath.localeCompare(right.skillPath));
-
-  const sourcePackages = await getSourcePackageMap(sourceSuites);
-  const suitesBySkillPath = new Map(
-    sourceSuites.map((suite) => [suite.skillPath, suite]),
-  );
-
-  for (const dependencyName of await getSkillDependencies(repoRoot)) {
-    const sourceSuite = sourcePackages.get(dependencyName);
-    if (sourceSuite) {
-      sourceSuite.packageName = dependencyName;
-      continue;
-    }
-
-    const skillSlug = dependencyName.slice(SKILL_PACKAGE_PREFIX.length);
-    const skillPath = join(
-      repoRoot,
-      'node_modules',
-      ...dependencyName.split('/'),
-    );
-    suitesBySkillPath.set(skillPath, {
-      evalPath: join(repoRoot, 'evals', skillSlug),
-      packageName: dependencyName,
-      skillPath,
-    });
-  }
-
-  return Array.from(suitesBySkillPath.values()).sort((left, right) =>
-    String(left.packageName ?? left.skillPath).localeCompare(
-      String(right.packageName ?? right.skillPath),
-    ),
-  );
-}
-
-async function getSourcePackageMap(sourceSuites) {
-  const packages = new Map();
-  for (const suite of sourceSuites) {
-    const packageJsonPath = join(suite.skillPath, 'package.json');
-    if (!existsSync(packageJsonPath)) continue;
-    const packageJson = await readJson(packageJsonPath);
-    if (typeof packageJson.name === 'string') {
-      packages.set(packageJson.name, suite);
-    }
-  }
-  return packages;
-}
-
-async function getSkillDependencies(repoRoot) {
-  const packageJson = await readJson(join(repoRoot, 'package.json'));
-  const dependencies = packageJson.dependencies ?? {};
-  return Object.keys(dependencies)
-    .filter((name) => name.startsWith(SKILL_PACKAGE_PREFIX))
-    .sort();
-}
-
 async function resolveEvalIds(suite, args) {
   if (args.evalIds) {
     return args.evalIds
@@ -197,13 +122,6 @@ async function resolveEvalIds(suite, args) {
     .map((evalItem) => evalItem.id)
     .filter((id) => Number.isInteger(id))
     .slice(0, args.maxEvalsPerSkill);
-}
-
-function suiteSlug(suite) {
-  if (suite.packageName?.startsWith(SKILL_PACKAGE_PREFIX)) {
-    return suite.packageName.slice(SKILL_PACKAGE_PREFIX.length);
-  }
-  return basename(suite.skillPath);
 }
 
 function parseList(value) {

--- a/scripts/skill-eval/run_trigger_online_all.mjs
+++ b/scripts/skill-eval/run_trigger_online_all.mjs
@@ -2,11 +2,8 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 import { spawn } from 'node:child_process';
-import { existsSync } from 'node:fs';
-import { readdir, readFile } from 'node:fs/promises';
-import { basename, join, resolve } from 'node:path';
-
-const SKILL_PACKAGE_PREFIX = '@lynx-js/skill-';
+import { join, resolve } from 'node:path';
+import { discoverSkillSuites, suiteSlug } from './discover_suites.mjs';
 
 main().catch((error) => {
   console.error(error instanceof Error ? error.message : String(error));
@@ -102,86 +99,6 @@ function parseArgs(argv) {
   return args;
 }
 
-async function discoverSkillSuites(repoRoot) {
-  const skillsRoot = join(repoRoot, 'packages/skills');
-  if (!existsSync(skillsRoot)) {
-    throw new Error(`skills directory not found: ${skillsRoot}`);
-  }
-
-  const entries = await readdir(skillsRoot, { withFileTypes: true });
-  const sourceSuites = entries
-    .filter((entry) => entry.isDirectory())
-    .map((entry) => {
-      const skillPath = join(skillsRoot, entry.name);
-      return {
-        evalPath: join(skillPath, 'evals'),
-        packageName: undefined,
-        skillPath,
-      };
-    })
-    .filter((suite) => existsSync(join(suite.skillPath, 'SKILL.md')))
-    .sort((left, right) => left.skillPath.localeCompare(right.skillPath));
-
-  const sourcePackages = await getSourcePackageMap(sourceSuites);
-  const suitesBySkillPath = new Map(
-    sourceSuites.map((suite) => [suite.skillPath, suite]),
-  );
-
-  for (const dependencyName of await getSkillDependencies(repoRoot)) {
-    const sourceSuite = sourcePackages.get(dependencyName);
-    if (sourceSuite) {
-      sourceSuite.packageName = dependencyName;
-      continue;
-    }
-
-    const skillSlug = dependencyName.slice(SKILL_PACKAGE_PREFIX.length);
-    const skillPath = join(
-      repoRoot,
-      'node_modules',
-      ...dependencyName.split('/'),
-    );
-    suitesBySkillPath.set(skillPath, {
-      evalPath: join(repoRoot, 'evals', skillSlug),
-      packageName: dependencyName,
-      skillPath,
-    });
-  }
-
-  return Array.from(suitesBySkillPath.values()).sort((left, right) =>
-    String(left.packageName ?? left.skillPath).localeCompare(
-      String(right.packageName ?? right.skillPath),
-    ),
-  );
-}
-
-async function getSourcePackageMap(sourceSuites) {
-  const packages = new Map();
-  for (const suite of sourceSuites) {
-    const packageJsonPath = join(suite.skillPath, 'package.json');
-    if (!existsSync(packageJsonPath)) continue;
-    const packageJson = await readJson(packageJsonPath);
-    if (typeof packageJson.name === 'string') {
-      packages.set(packageJson.name, suite);
-    }
-  }
-  return packages;
-}
-
-async function getSkillDependencies(repoRoot) {
-  const packageJson = await readJson(join(repoRoot, 'package.json'));
-  const dependencies = packageJson.dependencies ?? {};
-  return Object.keys(dependencies)
-    .filter((name) => name.startsWith(SKILL_PACKAGE_PREFIX))
-    .sort();
-}
-
-function suiteSlug(suite) {
-  if (suite.packageName?.startsWith(SKILL_PACKAGE_PREFIX)) {
-    return suite.packageName.slice(SKILL_PACKAGE_PREFIX.length);
-  }
-  return basename(suite.skillPath);
-}
-
 function parseList(value) {
   return new Set(
     String(value ?? '')
@@ -189,10 +106,6 @@ function parseList(value) {
       .map((item) => item.trim())
       .filter(Boolean),
   );
-}
-
-async function readJson(path) {
-  return JSON.parse(await readFile(path, 'utf8'));
 }
 
 function spawnInherited(command, args, cwd) {


### PR DESCRIPTION
## Summary

- Add shared skill eval suite discovery used by definition checks and online task/trigger runners.
- Prefer `node_modules/<skill package>/evals` for npm-installed skill packages when the package ships evals.
- Fall back to repository `evals/<skill-slug>` when a package does not include eval definitions.

## Validation

- `pnpm eval:skill:check:all`
- `pnpm eval:skill:task:online:all -- --dry-run --max-evals-per-skill 1 --skip-skills habitat-usage,vanilla-lynx`
- `pnpm eval:skill:trigger:online:all -- --dry-run --skip-skills habitat-usage,vanilla-lynx`
- `pnpm check`
- `pnpm test`
- `node --test scripts/validate-skills.test.mjs`
