### PR TITLE
feat(rspeedy-bundle-size): add bundle-size analysis skill

### DIFF
--- a/.changeset/rspeedy-bundle-size-new.md
+++ b/.changeset/rspeedy-bundle-size-new.md
@@ -1,0 +1,5 @@
+---
+'@lynx-js/skill-rspeedy-bundle-size': minor
+---
+
+Add the rspeedy-bundle-size skill: a measure-first workflow for analyzing and reducing the bundle size of rspeedy/Lynx (ReactLynx) apps — the three size levers (media, background JS, main-thread leakage) plus compile-layer knobs, with dual-thread architecture, rsdoctor/stats measurement, and cross-project triage.

--- a/packages/skills/rspeedy-bundle-size/SKILL.md
+++ b/packages/skills/rspeedy-bundle-size/SKILL.md
@@ -1,0 +1,198 @@
+---
+name: rspeedy-bundle-size
+description: Analyze and reduce the bundle size of rspeedy/Lynx (ReactLynx) apps — the size / `.lynx.bundle` lever (not runtime perf, types, or CI). Use when the user wants to optimize 包体积 / bundle size, find what is making a rspeedy bundle large, decide which size lever to pull, or shrink `main-thread.js` by stripping background-only code (jsb / telemetry / request / monitor SDKs) out of the render path via `__BACKGROUND__` / `'background only'` gating. Covers media, JS-background, and main-thread layers, plus mangle/eval-poisoning bloat, i18n-locale duplication, duplicate-package dedup, extractStr/compile knobs, and lazy/dynamic-component splitting (first-screen vs total size). Measure-first and evidence-based — produces a prioritized report; changes code only when asked.
+---
+
+# Rspeedy Bundle Optimization
+
+A measure-first workflow for shrinking the bundle of a rspeedy/Lynx app. The central discipline: **don't guess where the bytes are — measure, then attack the biggest lever first.** Most "optimize the bundle" requests fail by starting with micro-tree-shaking when the real weight is media assets or main-thread leakage.
+
+## Verify against source — do not guess
+
+The rspeedy / ReactLynx build behaves in non-obvious ways, and guessing is how you end up confidently wrong. **When you're unsure how the build, the layers, the ES targets, or stats/rsdoctor output actually behave, read the source — don't infer from naming or memory.** The whole toolchain is open source; clone or browse it and grep for the relevant plugin/util:
+
+The toolchain layers as **Rspack → Rsbuild → Rspeedy** (each builds on the one before), so a behavior may live in any layer — follow it down:
+
+- **rspeedy + ReactLynx plugins** (the `lynx-stack` monorepo): https://github.com/lynx-family/lynx-stack
+- **rsbuild** (the Rsbuild layer rspeedy is built on): https://github.com/web-infra-dev/rsbuild
+- **rspack** (the underlying bundler; stats/module types, layers, `output.environment`): https://github.com/web-infra-dev/rspack
+- **rsdoctor**: https://github.com/web-infra-dev/rsdoctor
+
+(Exact file paths aren't pinned here — they move between versions. Search by symbol, e.g. the ES-target util, the stats-json plugin, the entry/layer setup.) Several facts in this skill — main=ES2019 / background=ES2015, stats.json carrying `layer`, the entry→two-layer split — were each confirmed by reading the source or running a real build, not assumed. Hold new claims to the same bar.
+
+### NO GUESS — trace the real module graph, never narrate an import chain
+
+When the question is **"why is X bundled / who imports Y / what's the chain from the entry to Z"**, you must **trace the actual module graph — never describe a plausible chain** from `package.json`, intuition, or a half-answer like *"it comes in via the dependency tree, scope-hoisted into `./entry.tsx + 4630 modules`."* That `+ N modules` is the bundler hiding the edge from you, not an answer. To get the real edges:
+
+1. Build with `tools.rspack` setting **`optimization.moduleIds: 'named'`** AND **`optimization.concatenateModules: false`**. Scope-hoisting (`concatenateModules: true`, the prod default) **collapses importer edges** — every hoisted module's importer is reported as the whole concatenated group (`"./entry.tsx + N modules"`), so you literally cannot see who imports what. Disabling it is mandatory for chain tracing (it inflates size substantially — ~+70% observed on one project, varies by module graph — so it's analysis-only; revert after). **De-concat also disables `__split__`**, so components already split off the main thread reappear inflated in `main-thread.js` — cross-check any "huge popup/modal" against the real build before calling it a lazy-load candidate (see [rspeedy-gotchas.md §11](references/rspeedy-gotchas.md)).
+2. Read the **actual importer edges** from `stats.json`'s `reasons[].moduleName` (each module lists the modules that import it). On a big multi-entry build this file can reach **hundreds of MB to ~1 GB — too big for `readFileSync`** (`ERR_STRING_TOO_LONG`); stream it (`grep` / `readline`). (A single-page build with the default stats preset is far smaller — only `stats: { all: true }` or a many-page merge blows it up; see [measure-with-rsdoctor.md](references/measure-with-rsdoctor.md).)
+3. Walk the chain hop by hop and **report the exact file at each hop**. If you can't back a hop with a real reason edge, **you don't have the chain — say so, don't invent it.**
+
+Real example this rule comes from: an app's 1388-icon bloat *looked like* "app → business component lib → UI lib → icon barrel" — but the app imported **none** of those packages directly (0 hits in `src/`); only the de-concat `reasons` revealed the true edges. A narrated chain would have pointed the owner at the wrong file. **A dependency chain without real reason-edges behind it is a guess; do not present guesses as chains.**
+
+## When to use this skill
+
+- "帮我优化一下包体积" / "reduce the bundle size of this rspeedy app"
+- "为什么我的包这么大" / "what is making this bundle large"
+- After a build, the user wants the size broken down and a prioritized plan
+- Deciding whether tree-shaking is even worth it, vs media compression vs main-thread cleanup
+
+A distinct cause of an oversized bundle is **mangle failure** — readable module-prefixed names (`common_EVENT_NAME`, `utils_toSomething`) surviving in the production chunk, usually from `eval()` poisoning under ModuleConcatenation. It's covered as part of the JS lever in [references/three-levers.md](references/three-levers.md) §Lever 2.
+
+## When NOT to use this skill
+
+This is the **bundle-size / `.lynx.bundle`** lever only — it optimizes *shipped bytes*, not anything else. Route elsewhere for:
+- **Runtime / render performance** (jank, slow first paint, frame drops) — a different concern; this skill doesn't touch execution speed.
+- **JS memory / heap leaks** — use `lynx-js-heap-snapshot-analysis`.
+- **Directive *semantics*** (`'background only'` accepted forms / behavior) — defer to `reactlynx-best-practices`; this skill only *applies* the directive as a size lever.
+- **Deep `rsdoctor-data.json` forensics** (per-module retained-set, duplicate trees) — use `rsdoctor-analysis`; this skill only summarizes it.
+- **TS types / tsconfig** → `lynx-typescript`. **Decoding the tasm binary format** → `lynx-tasm-codec`.
+
+## Related skills
+
+If you have access to them, they go deeper on adjacent problems:
+
+- **`rsdoctor-analysis`** — deep analysis of `rsdoctor-data.json` (tree-shaking retained-modules, duplicate packages, side-effects). Use it for the heavy rsdoctor querying this skill only summarizes. Public: https://github.com/rstackjs/agent-skills/tree/main/skills/rsdoctor-analysis
+- **`reactlynx-best-practices`** — the authority on the dual-thread directives, incl. the `'background only'` / `'background-only'` function directive (see its `detect-background-only` rule). Defer to it for directive semantics and accepted forms rather than re-deriving them here.
+- **`rushstack-best-practices`** — use in Rush monorepos (detect `rush.json` / `common/config/rush`). Rush repos should normally use `rush`, `rushx`, or `rush-pnpm`, not raw `pnpm`. Public: https://github.com/microsoft/rushstack/blob/main/skills/rushstack-best-practices/SKILL.md
+
+## Build-system awareness
+
+Before measuring, identify the repo's build orchestrator and use its native command surface rather than assuming `pnpm build`:
+
+1. **Rush monorepo** — if `rush.json` or `common/config/rush/` exists, use the Rush skill. Run project scripts with `rushx <script>` from the project dir, or scoped repo commands such as `rush build --to .`; use `rush-pnpm` only when a pnpm command is truly necessary.
+2. **Custom wrapper tooling** — if scripts or config wrap `rspeedy` behind a company/monorepo CLI, prefer that documented entrypoint over calling `rspeedy`/`pnpm` directly.
+3. **Plain pnpm/npm project** — fall back to `pnpm` / `npm` directly when the repo is not Rush-managed and has no wrapper.
+
+Do not blindly run `pnpm build`. First read `package.json`, root workspace files, and any existing project docs; then choose the narrowest command that builds the target rspeedy app while preserving the repo's environment setup. If the project pins Node, use that version via your Node version manager (e.g. `fnm exec --using=<version> -- ...` or `nvm exec <version> ...`).
+
+## Triage first when you have many projects (don't build a whole fleet)
+
+The per-project workflow below is measure-first — but if you're handed a *fleet* ("optimize our Lynx bundles", a dashboard of 50+ apps), you can't build them all to decide where to look. Run a cheap **source-level triage** to rank which projects/levers deserve a real build, then measure-first the winners. A triage hit means "measure here", **not** "confirmed bloat".
+
+The scanner [references/assets/scan-levers.mjs](references/assets/scan-levers.mjs) walks each project's source (no build) and ranks by unguarded background-only leak, missing `sideEffects`, inline/large media, and duplicate deps:
+
+```bash
+node references/assets/scan-levers.mjs --glob <reposRoot>        # rank a fleet
+node references/assets/scan-levers.mjs <projectDir> --json out.json
+```
+
+Read [references/cross-project-triage.md](references/cross-project-triage.md) for how to interpret it and its traps (duplicate-dep counts are dominated by the dev toolchain and mostly noise; source presence ≠ main-thread presence; a telemetry signature over-counts a property name). Empirically across a real ~370-project fleet: **~74% have background-only leak signal in source, ~62% mostly unguarded, ~99% miss `sideEffects`** — telemetry + jsb/native glue is referenced almost everywhere and almost always unguarded.
+
+Telemetry/logging is background-only **only when it's jsb-backed** — a console-backed logger (`console.*`) runs on the main thread too, so confirm the underlying impl before treating a telemetry call as strippable. When it *is* jsb-backed it's a broadly-*relevant* Lever-3 signal — but measure before acting on it. The blind strip ([plugin-strip-mt-telemetry.ts](references/assets/plugin-strip-mt-telemetry.ts) + [loader](references/assets/strip-mt-telemetry-loader.cjs), method list customizable) netted only **−3.9 kB (−0.08%)** on a real project because the logger *imports* survived (the last-reference rule), so treat it as a **measurement aid, not the fix** (see [three-levers.md](references/three-levers.md) §Lever 3) — not a "drop it in and win" lever. By contrast one config line — `extractStr: true` — netted **−1.88% to −5.99%** across a 6-project fleet round (up to **−1.29 MB** on a 64-page string-heavy app; ~0 on thin demos or apps with little duplicated string content). **So on a string-heavy app not already using `extractStr`, just turning it on is the highest-ROI first move — far above hand-chasing telemetry leaks.** (Just set `extractStr: true`; tuning the `strLength` threshold is generally not recommended.)
+
+## The mental model: three layers, three levers
+
+A Lynx app bundle splits across two threads, plus non-JS assets. Size lives in three places, and the optimization technique is **different for each** — confusing them is the most common mistake.
+
+| Lever | What it is | Typical size | Who can fix it |
+|---|---|---|---|
+| **Media assets** | images/fonts inlined or shipped | often the single biggest chunk (multi-MB) | app code — usually highest ROI |
+| **JS — background thread** | `react:background` layer, app logic | varies | app code — tree-shaking, dedup |
+| **JS — main thread** | `react:main-thread` layer, first-screen render path | should be small; leaks happen | trace → **module split** (markers ≈ 0); big chains are **library asks** |
+
+See [references/three-levers.md](references/three-levers.md) for how to size and attack each.
+
+**Read [references/dual-thread-architecture.md](references/dual-thread-architecture.md) before optimizing if you don't already know why there are two JS layers** — it has the full model and the `代码裁剪` macro table that every Lever-3 fix relies on. In short: the **main thread** does first-screen direct render and must stay lean; the **background thread** carries logic / lifecycle / state. The build emits a `main-thread.js` + `background.js`, compiled into the binary **`.lynx.bundle`** the engine ships. ReactLynx auto-shakes `useEffect`/`componentDidMount`/`bindtap` callbacks out of `main-thread.js`; when it can't decide, steer it with `'background only'` or the `__BACKGROUND__`/`__MAIN_THREAD__` macros — that mechanism *is* the main-thread-leakage lever.
+
+## Core workflow
+
+### Step 1 — Measure (never skip)
+
+Get a real per-module breakdown before proposing anything. The official way for rspeedy is rsdoctor via config — **do not manually install `@rsdoctor/rspack-plugin`**, and do not reverse-engineer internal forks. Add to `lynx.config.ts`:
+
+```ts
+tools: {
+  rsdoctor: {
+    disableClientServer: true,
+    brief: { writeDataJson: true },
+  },
+}
+```
+
+Then build with `RSDOCTOR=true`. Full details, allowed config fields, and the sharded-data reconstruction trick are in [references/measure-with-rsdoctor.md](references/measure-with-rsdoctor.md).
+
+Use the build-system-aware command from the previous section:
+
+```bash
+# Rush project script
+RSDOCTOR=true rushx build
+
+# Wrapper-tooling project (example; prefer the repo's documented command)
+RSDOCTOR=true <wrapper> build
+
+# Plain package script
+RSDOCTOR=true pnpm build
+```
+
+A lighter alternative for a quick first look is rspeedy's built-in `stats.json` — turn it on with `performance.profile: true` in the config, or just build with `DEBUG=rspeedy` (it writes `output/stats.json`). It **does** carry a `layer` field per module (`react:main-thread` / `react:background`, verified on the demo), so it *can* separate the two threads. Prefer rsdoctor when you want per-module **gzip** sizes and duplicate/tree-shaking analysis for free; reach for stats.json for a fast layer-vs-size split with zero extra setup. Details in [references/measure-with-rsdoctor.md](references/measure-with-rsdoctor.md).
+
+### Step 2 — Classify the weight into the three layers
+
+From the rsdoctor `moduleGraph`, group `module.size.parsedSize` (and `gzipSize`) by:
+
+1. **Media / assets** — non-JS modules, or asset modules
+2. **JS `react:background`** — `module.layer` contains background
+3. **JS `react:main-thread`** — `module.layer` contains main-thread
+
+Report the three totals **first**. That number alone usually decides the whole engagement — e.g. "10MB of your 14MB is images; JS tree-shaking can win you ~50KB, so start with media."
+
+### Step 3 — Pick the lever by ROI, attack in order
+
+Default priority (override if the numbers say otherwise):
+
+```
+1. Media assets        → biggest, easiest wins (compress, dedup, format)
+2. JS background       → tree-shaking, duplicate packages, deep imports
+3. Main-thread leak    → background-only code that leaked into render path
+4. Compile-layer knobs → extractStr, CSS minify, debug-info, lazy bundle — often beats the JS tail
+```
+
+For each lever's concrete techniques and decision points, see [references/three-levers.md](references/three-levers.md) (Levers 1–4).
+
+### Step 4 — Know when to stop
+
+A well-optimized project hits a wall: tree-shaking is effectively exhausted (`sideEffects` set correctly — or, since ~99% of fleet projects omit the flag, the minifier already did the equivalent DCE), code-level DCE yields ~0 at the bundle level, and the remaining main-thread leak lives inside SDK libraries you can't edit. **Say so plainly.** Don't manufacture marginal changes to look busy — report the wall and what would move it (a library-side `'background only'` directive, an asset pipeline change in CI, etc.).
+
+**The structural-duplication wall (the most common shape on big pages — verified by deep-diving two real big apps).** A large `.lynx.bundle` is usually dominated not by leaks or dead code but by a **heavy resource the first-screen direct render genuinely needs, carried in BOTH layers** (main-thread *and* background each bundle their own copy under the dual-thread model). Two real examples: one app's page was **87% i18n locale JSON** (all 57 languages, in both layers); another was **62% a Pixi-like render engine** (~1.4 MB in *each* layer) that draws the first screen. When you see this, the usual app-side levers **all fail by construction**, and saying why is the deliverable:
+- **Can't lazy-split it** — it's first-screen-direct-render content; deferring it makes the first screen load a chunk mid-render (slower / FOUC). (This is the lazy-bundle rule applied: never lazy what first-screen needs.)
+- **Strip/DCE/dedup don't apply** — it's neither dead code nor a duplicate *package*; it's the same needed resource legitimately present on two threads.
+- **`extractStr` only helps the string-shaped case** — it dedups duplicated **string literals** across the two layers (i18n locale text, class names — that's why string-heavy apps shrink a lot under it), but it does **not** dedup duplicated **code** (a render engine), so it won't touch the engine case.
+
+So the real lever for these is **library/framework-level**, not app-side: a lighter library, a framework feature to share code across the two threads, or a host that injects the resource (e.g. the active locale) synchronously so the bundle needn't carry it. Measure the dominant chunk, name it, say which of these it needs — don't grind app-side config for a page whose weight is structural.
+
+## Gotchas specific to rspeedy/Lynx
+
+Several things will bite you if you treat this like a generic webpack project. Read [references/rspeedy-gotchas.md](references/rspeedy-gotchas.md) before editing config or asserting a finding. The headline traps:
+
+- **The two threads ship at fixed ES targets** — main-thread = ES2019, background = ES2015 (prod); both lower `let`/`const`→`var` for parse speed. These are engine-driven platform constants; don't propose retargeting to save bytes. (Some projects pin `output.environment` even lower, to full ES5, for parse time — a deliberate tradeoff, not the norm.)
+- **rsdoctor data may be sharded** (`.rsdoctor/` dir, not a single JSON) — reconstruct correctly or your numbers are wrong.
+- **builds need the pinned Node** (via fnm/nvm, e.g. `fnm exec --using=20.19.0` or `nvm exec 20.19.0`) — newer Node can break rspeedy config loading.
+
+## Logging convention — every optimization gets a `.bundle-opt-log/` entry
+
+**Required for any optimization (analysis or applied):** write a log entry under a hidden **`.bundle-opt-log/`** directory at the root of the project being optimized (e.g. `apps/<app>/.bundle-opt-log/`). The log's primary metric is **`.lynx.bundle` size before → after** (the shipped binary), per page.
+
+Each entry (one Markdown file per round, named by date + lever, e.g. `2026-06-04-icon-treeshake.md`) records:
+- **project / page**, and `.lynx.bundle` **before** and **after** (kB), with the **Δ and %**
+- the **lever** applied (one line), and whether it's **applied / proposed / wall**
+- the **verification build command** (so the number is reproducible), and the **Node version** if pinned
+- the **measurement caveat** if any (e.g. warm-cache vs cold — see gotchas §7; a delta under ~3% needs a warm re-measure)
+
+**Also maintain ONE consolidated tracking table** (e.g. `.bundle-opt-log/优化记录表.md` / `SUMMARY.md`): a single Markdown table with **one row per optimization** — `优化项 | .lynx.bundle 前 | 后 | Δ | 机制 | commit` — plus a cumulative total row, and a second table for investigated-but-not-shipped levers (with their measured Δ, often ~0, and the reason). Append a row every time you land an optimization; chain the before/after so each row's "before" = previous row's "after". This is the at-a-glance ledger; the per-round files hold the detail. Owners specifically ask for this table — keep it current.
+
+Keep it `.lynx.bundle`-centric: intermediate `main-thread.js`/`background.js` numbers are supporting detail, but the headline is always the shipped `.lynx.bundle` before/after. Put build *artifacts* (intermediates, analysis de-concat dumps) under the gitignored build output dir (`output/` or `dist/`), **never** in a new top-level dir — only the `.bundle-opt-log/` markdown is meant to live in the repo. Confirm with the owner whether `.bundle-opt-log/` should be committed or gitignored before creating it.
+
+## Stance: report-first, read-only by default
+
+Like the other analysis skills here, default to **producing a prioritized report, not editing code**. Present findings + options + tradeoffs; let the user choose what to change. Only modify app code when explicitly asked, and keep changes surgical.
+
+## Response format
+
+1. **Measured breakdown** — the three-layer totals (media / bg JS / main JS), biggest modules in each
+2. **Biggest lever** — which layer dominates and why
+3. **Prioritized actions** — table of action → est. savings → effort → who can do it (app vs library vs CI)
+4. **Main-thread leakage trace** — if any leak exists, include the suspicious module plus its upstream importer path / owner; don't only report the leaked API string
+5. **Compile-layer quick wins** — `extractStr` / CSS minify / debug-info / lazy-bundle knobs tried or proposed (Lever 4)
+6. **The wall** — what's already optimal and what external change would be needed to go further
+7. **Log entry** — write the `.bundle-opt-log/` entry and append to the tracking table (see Logging convention)

--- a/packages/skills/rspeedy-bundle-size/SKILL.md
+++ b/packages/skills/rspeedy-bundle-size/SKILL.md
@@ -99,7 +99,9 @@ See [references/three-levers.md](references/three-levers.md) for how to size and
 
 ### Step 1 — Measure (never skip)
 
-Get a real per-module breakdown before proposing anything. The official way for rspeedy is rsdoctor via config — **do not manually install `@rsdoctor/rspack-plugin`**, and do not reverse-engineer internal forks. Add to `lynx.config.ts`:
+Get a real per-module breakdown before proposing anything. **This holds even when the user already hands you rough sizes (e.g. "images ~10MB, JS ~4MB") or asks you to just do a specific change** — a glance at output sizes is a starting hypothesis, not a per-module measurement. **Always confirm the breakdown with rsdoctor (or `stats.json`) and lead with the prioritized recommendation *before* committing to — or implementing — any lever**, including a change the user explicitly requested. If the asked-for change is the wrong (low-ROI) lever, say so first; only proceed with it after the measured breakdown confirms it's worth it.
+
+The official way for rspeedy is rsdoctor via config — **do not manually install `@rsdoctor/rspack-plugin`**, and do not reverse-engineer internal forks. Add to `lynx.config.ts`:
 
 ```ts
 tools: {

--- a/packages/skills/rspeedy-bundle-size/evals/README.md
+++ b/packages/skills/rspeedy-bundle-size/evals/README.md
@@ -1,0 +1,46 @@
+# Evals for `rspeedy-bundle-size`
+
+These evals follow the [skill-creator](https://github.com/anthropics/skills/blob/main/skills/skill-creator/SKILL.md) methodology, adapted for a **decision/methodology skill**: the skill's job is to make the agent reach the *right call* on a bundle-size question, so each eval is a realistic scenario and the `expectations` check the **decision**, not a built artifact. No real rspeedy build is needed to run them — they're fast text evals.
+
+## Files (same layout as the other Lynx skills' `evals/`)
+- `evals.json` — the task eval set. Top-level `skill_name` + `description` + `evals[]`; each eval is `{ id, name, prompt, expected_output, expectations[], files[] }`, where `expectations` are plain-string criteria graded independently. These are full tasks that should exercise the skill when loaded (with-skill vs baseline), **not** trigger queries.
+- `trigger_eval.json` — the description/trigger-optimization set: a flat array of `{ query, should_trigger }` (~12 should-trigger / ~10 should-not). The negatives are deliberately tricky: Lynx-ecosystem questions that belong to *other* skills (runtime perf, `lynx-typescript`, `reactlynx-class2fc`, `lynx-tasm-codec`, heap analysis, deep `rsdoctor-analysis`) plus wrong-platform bundle questions (React-web webpack, Next.js). Feed this to skill-creator's `scripts.run_loop --eval-set trigger_eval.json` to tune the SKILL.md `description`.
+
+## Why these scenarios
+Each targets a **counter-intuitive, evidence-backed lesson** from the skill — the places where a no-skill baseline tends to give generic or wrong advice:
+
+| # | Scenario | Lesson under test |
+|---|---|---|
+| 1 | 14MB bundle, 10MB media, user wants to start with lodash | measure-first; media is the biggest lever, not JS micro-tree-shaking |
+| 2 | "who imports this 1388-icon lib?" (no source import) | NO GUESS — trace the real module graph (de-concat + `reasons`), never narrate a chain |
+| 3 | main-thread.js 87% locale JSON, wants to lazy-load it | never lazy-split first-screen content; fix i18n bloat via `extractStr`/host-injection |
+| 4 | `import()` made .lynx.bundle bigger and didn't shake the SDK | `import()` regresses .lynx.bundle; use a macro guard; last-reference rule |
+| 5 | `typeof NativeModules` runtime check still bundles the SDK | promote runtime check → compile-time `__BACKGROUND__` macro for DCE |
+| 6 | "does lazy reduce total app size?" | lazy is a first-screen lever; it *increases* total |
+| 7 | "give me a big list of more JS wins" on a tidy project | report the wall honestly; don't manufacture marginal diffs |
+| 8 | optimize a Lynx app in a repo with `rush.json` | use the Rush command surface, not raw `pnpm build` |
+| 9 | "retarget to newer ES to save bytes?" | ES targets are fixed engine constants; don't retarget |
+| 10 | de-concat treemap shows 870KB icons / 21KB package.json | de-concat over-counts; quote only real `.lynx.bundle` deltas |
+
+## Running (with-skill vs baseline)
+For each eval, run two arms **in parallel** (don't stagger):
+- **with_skill** — agent is given the active `SKILL.md` and the skill directory path (so it can read `references/`), then the eval `prompt`.
+- **baseline** — a fresh agent given only the eval `prompt` (no skill).
+
+This isolates the skill's lift. Save each arm's final answer per eval.
+
+## Grading
+Grade **each `expectations` entry independently** against an arm's answer. Use exactly these fields (skill-creator viewer convention):
+```json
+{ "text": "<the expectation criterion>", "passed": true, "evidence": "<verbatim span from the answer that satisfies/violates it>" }
+```
+Rules:
+- `passed` only if the answer *actively makes* the decision the expectation describes (not merely "doesn't contradict it").
+- `evidence` must be a real quote from the graded answer (or "" with `passed:false` if absent).
+- Grade with-skill and baseline by the **same** rubric.
+
+## Pass criteria (this harness)
+- **with_skill expectation pass rate ≥ 0.90**, and
+- **lift over baseline ≥ 25pp** (skill must demonstrably help, not just ride the base model).
+
+Iterate the skill on failing expectations, re-run, repeat until both hold or progress stalls.

--- a/packages/skills/rspeedy-bundle-size/evals/evals.json
+++ b/packages/skills/rspeedy-bundle-size/evals/evals.json
@@ -1,0 +1,126 @@
+{
+  "skill_name": "rspeedy-bundle-size",
+  "description": "End-to-end decision/methodology evals for the rspeedy-bundle-size skill. The skill is a measure-first decision skill, so each prompt is a realistic zh/en user scenario and the expectations check whether the agent makes the right CALL — not whether it runs a build (no real rspeedy build is needed). Scenarios target the skill's counter-intuitive, evidence-backed lessons where a no-skill baseline tends to give generic or wrong advice. Use with the skill-creator workflow to compare with-skill vs baseline outputs; grade each expectation independently as pass/fail with a verbatim evidence span.",
+  "evals": [
+    {
+      "id": 1,
+      "name": "media-dominates-measure-first",
+      "prompt": "我的 rspeedy/Lynx 应用打包后 template 很大,大概 14MB。我看了下 output,图片资源大概 10MB,JS 大概 4MB。我打算先把 lodash 换成 lodash-es 做 tree-shaking 来减小体积,帮我搞一下。",
+      "expected_output": "Stops the user from starting with lodash. Points out media (~10MB) dwarfs JS (~4MB), so media is the highest-ROI lever and must be attacked first (WebP/quantize/dedup/subset); lodash tree-shaking wins ~tens of KB at most. Recommends confirming the breakdown with a real per-module measurement (rsdoctor/stats) before committing, and notes local builds may not compress media (CI-gated image plugins).",
+      "expectations": [
+        "Identifies media (~10MB) as the dominant lever to attack first, ahead of JS tree-shaking.",
+        "Pushes back on starting with lodash/JS tree-shaking, noting it wins comparatively little (tens of KB) when media dominates.",
+        "Recommends measuring/confirming the breakdown (e.g. per-module via rsdoctor or stats.json) before committing to changes."
+      ],
+      "files": []
+    },
+    {
+      "id": 2,
+      "name": "no-guess-trace-real-graph",
+      "prompt": "rsdoctor 显示有个图标库被打进来了 1388 个图标,但我在 src 里全局搜了一下,根本没有任何文件 import 这个库。到底是哪条链路把它引进来的?直接告诉我是谁 import 的。",
+      "expected_output": "Refuses to narrate a plausible chain. Explains the real importer edges must be read from the module graph: rebuild with optimization.concatenateModules:false (scope-hoisting collapses importer edges into '+ N modules') AND moduleIds:'named', then read reasons[].moduleName hop by hop (streaming the possibly ~1GB stats.json). States plainly that without real reason-edges it can only guess, and a guessed chain could point at the wrong file.",
+      "expectations": [
+        "Recommends tracing the actual module graph via reason/importer edges (rsdoctor graph or stats.json reasons) rather than narrating a plausible import chain.",
+        "Specifies disabling scope-hoisting (concatenateModules:false) and/or moduleIds:'named' to expose the real importer edges (because concatenation collapses them into '+ N modules').",
+        "Explicitly declines to invent/guess the chain without evidence, instead of confidently naming an importer."
+      ],
+      "files": []
+    },
+    {
+      "id": 3,
+      "name": "i18n-structural-wall-no-lazy-locale",
+      "prompt": "我的 main-thread.js 有 2.6MB,其中大概 87% 是 src/i18n/locales 下 57 种语言的 JSON。我想把 locales 改成动态 import() 懒加载来减小体积,这样可以吗?",
+      "expected_output": "Warns NO: the active locale is first-screen-direct-render content (the main thread renders translated text on first paint), so lazy-splitting it slows the first screen or flashes untranslated text — never lazy-split what first-screen needs. The real bloat is duplication (every language, in BOTH main-thread and background layers). First-screen-safe fixes: extractStr (dedup the duplicated strings into a shared table, no defer) or host-injected active locale (architecture change). It's a structural/library-level issue, not dead code.",
+      "expectations": [
+        "Warns against lazy-loading the active locale because it is first-screen-direct-render content (lazy would slow/flash the first screen).",
+        "Recommends extractStr (shared string table) and/or a host-injected active locale as the first-screen-safe way to claim the bytes.",
+        "Notes the bloat is duplication of the locales across both the main-thread and background layers (a structural issue), not removable dead code."
+      ],
+      "files": []
+    },
+    {
+      "id": 4,
+      "name": "import-regresses-use-macro-guard",
+      "prompt": "我把一个后台才会用到的 SDK 用 dynamic import() 拆出主线程,想让它别进 main-thread。结果 .lynx.bundle 反而变大了,而且这个 SDK 还在 main-thread 里没走掉。为什么?应该怎么做?",
+      "expected_output": "Explains import() does not remove bytes from .lynx.bundle — a Lynx page's .lynx.bundle packages its async chunks, so import() emits a separate lazy chunk AND keeps/duplicates content plus loader/runtime overhead → .lynx.bundle grows. And it didn't shake because other main-thread references kept the SDK alive (last-reference rule). The right tool is a compile-time guard `if (__MAIN_THREAD__) return;` (or __BACKGROUND__) on every consumer function — zero added bytes, can't worsen the bundle — and you must gate ALL main-thread references before the subtree shakes.",
+      "expectations": [
+        "Explains dynamic import() does not reduce .lynx.bundle (adds a chunk + loader/runtime overhead, .lynx.bundle packages its async chunks) and can regress it.",
+        "Recommends a compile-time __MAIN_THREAD__/__BACKGROUND__ guard (or the 'background only' directive) on the consumer code instead of import().",
+        "States the last-reference rule: the SDK only shakes out of main-thread once ALL of its main-thread references are gated/removed."
+      ],
+      "files": []
+    },
+    {
+      "id": 5,
+      "name": "runtime-check-to-compile-time-macro",
+      "prompt": "我有一行:const Monitor = typeof NativeModules !== 'undefined' ? createMonitorInstance({...}) : null。NativeModules 是 jsb,所以主线程里 Monitor 一直是 null。但 rsdoctor 显示 createMonitorInstance 和它的插件还是被打进了 main-thread。怎么去掉这部分体积?",
+      "expected_output": "rspack can't prove the runtime typeof check, so it bundles the SDK branch into main-thread anyway. Promote the condition to a compile-time macro: __BACKGROUND__ && typeof NativeModules !== 'undefined' — rspack then statically DCEs the createMonitorInstance branch on the main-thread layer. Runtime behavior is byte-identical (still null on main thread, unchanged on background); no stub needed; consumers already optional-chain Monitor?.x. This is the safest kind of win — always look for runtime thread/host checks gating a heavy construct and promote them.",
+      "expectations": [
+        "Recommends adding a compile-time macro (__BACKGROUND__, e.g. `__BACKGROUND__ && typeof NativeModules...`) so rspack can statically DCE the SDK on the main-thread layer.",
+        "Notes the change is correctness-neutral / behavior-identical (still null on main thread) and needs no stub.",
+        "States the last-reference rule — if `createMonitorInstance` has other un-gated main-thread references, those must be gated too before the SDK subtree shakes (and does not reach for dynamic import())."
+      ],
+      "files": []
+    },
+    {
+      "id": 6,
+      "name": "lazy-firstscreen-not-total",
+      "prompt": "我想用 React 的 lazy/Suspense 把一些组件拆成动态 bundle,这样能把整个 app 的总包体积降下来吗?",
+      "expected_output": "Distinguishes the metric: lazy reduces the FIRST-SCREEN / initial-download size, but INCREASES total download — each lazy bundle is a standalone template that re-includes framework runtime/wrapper overhead (roughly fixed per bundle), so it ships more bytes overall. If total/whole-app size is the goal, lazy is the wrong tool. If first-screen is the goal, consolidate into a FEW BIG lazy bundles (split the single biggest deferrable cluster), not many small ones, and only defer genuinely non-first-screen surface.",
+      "expectations": [
+        "Distinguishes first-screen/initial-download size (which lazy improves) from total bundle size (which lazy worsens or does not reduce).",
+        "Explains lazy bundles add per-bundle framework/runtime overhead, so total download grows.",
+        "Advises consolidating into few large lazy bundles (biggest deferrable cluster) rather than many small ones, if pursuing first-screen."
+      ],
+      "files": []
+    },
+    {
+      "id": 7,
+      "name": "report-the-wall-honestly",
+      "prompt": "这个项目我已经做完了一整轮 JS 优化:sideEffects 配好、重复依赖 dedup、tree-shaking,连 Lynx 特有的也做了——extractStr 开了、CSS minify 开了、main-thread 泄漏也用 __BACKGROUND__/'background only' 审过并 gate 了,媒体也走了 CI 压缩。现在 JS 这块还能再榨出体积吗?给我越多能改的点越好,别藏着。",
+      "expected_output": "Resists manufacturing a long list of marginal changes to look busy. Recognizes that with all the classic AND Lynx-specific levers already done, the project is at the wall: line-by-line code DCE / ts-prune 'unused exports' churn nets ~0 at the bundle level once tree-shaking is done. States this honestly and redirects to where the real remaining weight lives — media (a CI/asset-pipeline change), a main-thread leak that lives inside SDK libraries you can't edit from app code (a library-side change / upstream ask), or structural duplication (a heavy first-screen resource carried in both layers, e.g. an i18n table or a render engine). The deliverable is an accurate map and what external change would move the wall, not a pile of marginal diffs.",
+      "expectations": [
+        "Recognizes the project is at/near the optimization wall and says so honestly, instead of padding a list with marginal or generic webpack-style changes.",
+        "Notes that line-by-line code DCE / ts-prune 'unused exports' churn nets ~0 at the bundle level once tree-shaking is already done.",
+        "Redirects to where the real remaining weight lives (media/CI pipeline, a main-thread leak inside SDK libraries needing a library/upstream change, or structural duplication) and/or names the external change that would move the wall."
+      ],
+      "files": []
+    },
+    {
+      "id": 8,
+      "name": "build-system-awareness-rush",
+      "prompt": "帮我在这个仓库里优化某个 Lynx 应用的包体积。仓库根目录有 rush.json。我直接在项目目录跑 `pnpm build` 来出包就行吧?",
+      "expected_output": "Identifies the repo as a Rush monorepo (rush.json) and advises against a raw `pnpm build`. Recommends the Rush-native command surface — `rushx <script>` from the project dir, or `rush build --to .` — and `rush-pnpm` only when a pnpm command is truly necessary. Also: read package.json / workspace config first and use the project's pinned Node via fnm/nvm (e.g. fnm exec --using=<version> or nvm exec <version>).",
+      "expectations": [
+        "Identifies the repo as a Rush monorepo (from rush.json) and advises against a raw `pnpm build`.",
+        "Recommends the Rush-native command surface (rushx / rush build --to . / rush-pnpm).",
+        "Notes the build should use the project's pinned Node version via fnm/nvm (e.g. `fnm exec --using=<version>` or `nvm exec <version>`), since a newer default Node can break rspeedy config loading."
+      ],
+      "files": []
+    },
+    {
+      "id": 9,
+      "name": "es-target-do-not-retarget",
+      "prompt": "rspeedy 的输出看起来像 es2015/es2019。我把 output target 调到更新的 ES 版本,是不是就能省一点体积?",
+      "expected_output": "Declines: the two threads ship at fixed, engine-driven ES baselines — main thread = ES2019, background = ES2015 (prod) — and these are platform constants, not knobs to turn for bytes. Retargeting saves ~nothing and fights the platform. Also notes let/const→var lowering is a deliberate parse-time choice (QuickJS parses var faster), not a missed optimization. (A project may pin even lower to full ES5 for parse time, which is slightly LARGER in bytes — a deliberate tradeoff.)",
+      "expectations": [
+        "Declines retargeting to save bytes, explaining the ES targets are fixed/engine-driven platform constants (main ES2019 / background ES2015 in prod).",
+        "Notes let/const→var lowering is a deliberate parse-time choice, not a missed optimization (or that lower ES is not smaller).",
+        "Redirects to where real byte savings actually live (media, background-JS dedup/tree-shaking, main-thread leak, extractStr) instead of the ES target."
+      ],
+      "files": []
+    },
+    {
+      "id": 10,
+      "name": "deconcat-overcounts",
+      "prompt": "我用 concatenateModules:false 重新 build 了一版来分析体积,treemap 里看到一个图标库占 870KB,还有某个 SDK 把它的 package.json 也打进来了占 21KB,看着都像能省下来的。这些数字我能直接当成能省的体积吗?",
+      "expected_output": "Warns NO: a concatenateModules:false (de-concat) build systematically INFLATES module sizes and disables JSON tree-shaking, scope-hoist DCE, and __split__ — so those numbers are not realizable wins. De-concat is for finding importer EDGES / candidates only; real savings must be measured as production .lynx.bundle before/after deltas. Concretely the 21KB package.json likely nets ~0 in the real build (prod tree-shakes the JSON to its one used key), and the 870KB icons measured ~441KB real. Quote only real .lynx.bundle deltas as wins.",
+      "expectations": [
+        "Warns that concatenateModules:false (de-concat) sizes are systematically inflated and must not be quoted as realizable wins.",
+        "States real savings must be measured as production .lynx.bundle before/after deltas (de-concat is for finding importer edges/candidates only).",
+        "Notes de-concat disables JSON tree-shaking / scope-hoist DCE, so e.g. the bundled package.json likely nets ~0 in the real build."
+      ],
+      "files": []
+    }
+  ]
+}

--- a/packages/skills/rspeedy-bundle-size/evals/evals.json
+++ b/packages/skills/rspeedy-bundle-size/evals/evals.json
@@ -5,7 +5,7 @@
     {
       "id": 1,
       "name": "media-dominates-measure-first",
-      "prompt": "我的 rspeedy/Lynx 应用打包后 template 很大,大概 14MB。我看了下 output,图片资源大概 10MB,JS 大概 4MB。我打算先把 lodash 换成 lodash-es 做 tree-shaking 来减小体积,帮我搞一下。",
+      "prompt": "My rspeedy/Lynx app's bundle is large after building — about 14MB. Looking at output, images are ~10MB and JS is ~4MB. I'm planning to start by switching lodash to lodash-es for tree-shaking to cut the size — help me do that.",
       "expected_output": "Stops the user from starting with lodash. Points out media (~10MB) dwarfs JS (~4MB), so media is the highest-ROI lever and must be attacked first (WebP/quantize/dedup/subset); lodash tree-shaking wins ~tens of KB at most. Recommends confirming the breakdown with a real per-module measurement (rsdoctor/stats) before committing, and notes local builds may not compress media (CI-gated image plugins).",
       "expectations": [
         "Identifies media (~10MB) as the dominant lever to attack first, ahead of JS tree-shaking.",
@@ -41,7 +41,7 @@
     {
       "id": 4,
       "name": "import-regresses-use-macro-guard",
-      "prompt": "我把一个后台才会用到的 SDK 用 dynamic import() 拆出主线程,想让它别进 main-thread。结果 .lynx.bundle 反而变大了,而且这个 SDK 还在 main-thread 里没走掉。为什么?应该怎么做?",
+      "prompt": "I tried to pull a background-only SDK off the main thread with a dynamic import() so it wouldn't land in main-thread. But the .lynx.bundle got BIGGER, and the SDK is still in main-thread. Why, and what should I do instead?",
       "expected_output": "Explains import() does not remove bytes from .lynx.bundle — a Lynx page's .lynx.bundle packages its async chunks, so import() emits a separate lazy chunk AND keeps/duplicates content plus loader/runtime overhead → .lynx.bundle grows. And it didn't shake because other main-thread references kept the SDK alive (last-reference rule). The right tool is a compile-time guard `if (__MAIN_THREAD__) return;` (or __BACKGROUND__) on every consumer function — zero added bytes, can't worsen the bundle — and you must gate ALL main-thread references before the subtree shakes.",
       "expectations": [
         "Explains dynamic import() does not reduce .lynx.bundle (adds a chunk + loader/runtime overhead, .lynx.bundle packages its async chunks) and can regress it.",
@@ -65,7 +65,7 @@
     {
       "id": 6,
       "name": "lazy-firstscreen-not-total",
-      "prompt": "我想用 React 的 lazy/Suspense 把一些组件拆成动态 bundle,这样能把整个 app 的总包体积降下来吗?",
+      "prompt": "I want to use React lazy/Suspense to split some components into dynamic bundles — will that reduce my whole app's TOTAL bundle size?",
       "expected_output": "Distinguishes the metric: lazy reduces the FIRST-SCREEN / initial-download size, but INCREASES total download — each lazy bundle is a standalone template that re-includes framework runtime/wrapper overhead (roughly fixed per bundle), so it ships more bytes overall. If total/whole-app size is the goal, lazy is the wrong tool. If first-screen is the goal, consolidate into a FEW BIG lazy bundles (split the single biggest deferrable cluster), not many small ones, and only defer genuinely non-first-screen surface.",
       "expectations": [
         "Distinguishes first-screen/initial-download size (which lazy improves) from total bundle size (which lazy worsens or does not reduce).",
@@ -101,7 +101,7 @@
     {
       "id": 9,
       "name": "es-target-do-not-retarget",
-      "prompt": "rspeedy 的输出看起来像 es2015/es2019。我把 output target 调到更新的 ES 版本,是不是就能省一点体积?",
+      "prompt": "rspeedy's output looks like es2015/es2019. If I bump the output target to a newer ES version, will that save some bytes?",
       "expected_output": "Declines: the two threads ship at fixed, engine-driven ES baselines — main thread = ES2019, background = ES2015 (prod) — and these are platform constants, not knobs to turn for bytes. Retargeting saves ~nothing and fights the platform. Also notes let/const→var lowering is a deliberate parse-time choice (QuickJS parses var faster), not a missed optimization. (A project may pin even lower to full ES5 for parse time, which is slightly LARGER in bytes — a deliberate tradeoff.)",
       "expectations": [
         "Declines retargeting to save bytes, explaining the ES targets are fixed/engine-driven platform constants (main ES2019 / background ES2015 in prod).",
@@ -113,7 +113,7 @@
     {
       "id": 10,
       "name": "deconcat-overcounts",
-      "prompt": "我用 concatenateModules:false 重新 build 了一版来分析体积,treemap 里看到一个图标库占 870KB,还有某个 SDK 把它的 package.json 也打进来了占 21KB,看着都像能省下来的。这些数字我能直接当成能省的体积吗?",
+      "prompt": "I rebuilt with concatenateModules:false to analyze size. In the treemap an icon lib shows 870KB, and some SDK bundled its package.json for 21KB — both look removable. Can I take these numbers as the bytes I'll actually save?",
       "expected_output": "Warns NO: a concatenateModules:false (de-concat) build systematically INFLATES module sizes and disables JSON tree-shaking, scope-hoist DCE, and __split__ — so those numbers are not realizable wins. De-concat is for finding importer EDGES / candidates only; real savings must be measured as production .lynx.bundle before/after deltas. Concretely the 21KB package.json likely nets ~0 in the real build (prod tree-shakes the JSON to its one used key), and the 870KB icons measured ~441KB real. Quote only real .lynx.bundle deltas as wins.",
       "expectations": [
         "Warns that concatenateModules:false (de-concat) sizes are systematically inflated and must not be quoted as realizable wins.",

--- a/packages/skills/rspeedy-bundle-size/evals/trigger_eval.json
+++ b/packages/skills/rspeedy-bundle-size/evals/trigger_eval.json
@@ -1,0 +1,90 @@
+[
+  {
+    "query": "我这个 rspeedy/Lynx 应用打包出来的 .lynx.bundle 有 14MB,帮我分析下到底大在哪、怎么减小包体积",
+    "should_trigger": true
+  },
+  {
+    "query": "My ReactLynx app's bundle is around 8MB. How do I figure out what's making it so big and cut it down?",
+    "should_trigger": true
+  },
+  {
+    "query": "rsdoctor 显示我 main-thread.js 里有一堆 background-only 的埋点/请求 SDK,怎么把它们从主线程剥离掉减小体积",
+    "should_trigger": true
+  },
+  {
+    "query": "Lynx 包体积怎么量?我想知道我这个页面的 .lynx.bundle 里到底是图片大还是 JS 大,先搞清楚再优化",
+    "should_trigger": true
+  },
+  {
+    "query": "production 包里出现了 common_EVENT_NAME、utils_toSomething 这种没被压缩的变量名,体积也偏大,什么原因怎么修",
+    "should_trigger": true
+  },
+  {
+    "query": "我们的 i18n 把 57 种语言全打进 bundle 了,占了 main-thread 一大半体积,这块能不能优化掉",
+    "should_trigger": true
+  },
+  {
+    "query": "想把后台才用的 SDK 用 __BACKGROUND__ 或 'background only' 从主线程裁掉,具体怎么做最稳、会不会改坏",
+    "should_trigger": true
+  },
+  {
+    "query": "extractStr 这个配置对减小 Lynx 的 .lynx.bundle 有用吗?strLength 阈值设多少合适",
+    "should_trigger": true
+  },
+  {
+    "query": "用 lazy / dynamic import 把组件拆成动态 bundle,能把我 Lynx app 的总包体积降下来吗?",
+    "should_trigger": true
+  },
+  {
+    "query": "我们有 50 多个 Lynx 应用,想批量看哪些工程的包体积还有优化空间,从哪些先下手",
+    "should_trigger": true
+  },
+  {
+    "query": "rspeedy build 出来的产物太大了,帮我做个体积拆解和优化优先级排序",
+    "should_trigger": true
+  },
+  {
+    "query": "同一个库被打了两个版本进 Lynx bundle,体积翻倍了,怎么 dedup 成一份",
+    "should_trigger": true
+  },
+  {
+    "query": "我的 Lynx 页面首帧渲染很慢、滑动列表也卡顿,帮我排查运行时渲染性能",
+    "should_trigger": false
+  },
+  {
+    "query": "ReactLynx 里 lynx.__globalProps.appTheme 报 TS 类型错误 Property 'appTheme' does not exist,怎么声明类型",
+    "should_trigger": false
+  },
+  {
+    "query": "帮我把这个 ReactLynx 的 class 组件改写成函数组件 + hooks",
+    "should_trigger": false
+  },
+  {
+    "query": "我这个纯 React Web 项目用 webpack 打包,bundle 太大了,帮我做 tree-shaking 和 code splitting 优化",
+    "should_trigger": false
+  },
+  {
+    "query": "我想解码/分析 Lynx 的 tasm 二进制,看看 template 文件里的结构和指令是怎么编码的",
+    "should_trigger": false
+  },
+  {
+    "query": "Lynx app 线上崩溃了,我有一段 native stacktrace 和 sourcemap,帮我 remap 还原符号",
+    "should_trigger": false
+  },
+  {
+    "query": "我想深入查 rsdoctor-data.json 里 tree-shaking 到底保留了哪些模块、有哪些 side-effects 没摇掉,做细粒度模块分析",
+    "should_trigger": false
+  },
+  {
+    "query": "Lynx 应用内存占用偏高,帮我抓个 heap snapshot 分析一下哪里泄漏了",
+    "should_trigger": false
+  },
+  {
+    "query": "Next.js App Router 的 bundle 怎么优化?RSC 和 client component 拆分后首屏 JS 还是太大",
+    "should_trigger": false
+  },
+  {
+    "query": "帮我给这个 Lynx 项目配一条 CI/CD 流水线,build 完自动上传产物",
+    "should_trigger": false
+  }
+]

--- a/packages/skills/rspeedy-bundle-size/evals/trigger_eval.json
+++ b/packages/skills/rspeedy-bundle-size/evals/trigger_eval.json
@@ -8,7 +8,7 @@
     "should_trigger": true
   },
   {
-    "query": "rsdoctor 显示我 main-thread.js 里有一堆 background-only 的埋点/请求 SDK,怎么把它们从主线程剥离掉减小体积",
+    "query": "rsdoctor shows a bunch of background-only tracking/request SDKs sitting in my main-thread.js — how do I strip them off the main thread to shrink the bundle?",
     "should_trigger": true
   },
   {
@@ -16,7 +16,7 @@
     "should_trigger": true
   },
   {
-    "query": "production 包里出现了 common_EVENT_NAME、utils_toSomething 这种没被压缩的变量名,体积也偏大,什么原因怎么修",
+    "query": "My production bundle has un-minified names like common_EVENT_NAME and utils_toSomething and it's larger than expected — what causes this and how do I fix it?",
     "should_trigger": true
   },
   {
@@ -24,15 +24,15 @@
     "should_trigger": true
   },
   {
-    "query": "想把后台才用的 SDK 用 __BACKGROUND__ 或 'background only' 从主线程裁掉,具体怎么做最稳、会不会改坏",
+    "query": "I want to cut a background-only SDK off the main thread with __BACKGROUND__ or a 'background only' directive — what's the safest way to do it without breaking the build?",
     "should_trigger": true
   },
   {
-    "query": "extractStr 这个配置对减小 Lynx 的 .lynx.bundle 有用吗?strLength 阈值设多少合适",
+    "query": "extractStr 这个配置对减小 Lynx 的 .lynx.bundle 有用吗?该怎么开",
     "should_trigger": true
   },
   {
-    "query": "用 lazy / dynamic import 把组件拆成动态 bundle,能把我 Lynx app 的总包体积降下来吗?",
+    "query": "Will using lazy / dynamic import to split components into dynamic bundles reduce my Lynx app's TOTAL bundle size?",
     "should_trigger": true
   },
   {
@@ -40,7 +40,7 @@
     "should_trigger": true
   },
   {
-    "query": "rspeedy build 出来的产物太大了,帮我做个体积拆解和优化优先级排序",
+    "query": "The .lynx.bundle from my rspeedy build is too big — can you break down its size and give me a prioritized optimization plan?",
     "should_trigger": true
   },
   {
@@ -48,7 +48,7 @@
     "should_trigger": true
   },
   {
-    "query": "我的 Lynx 页面首帧渲染很慢、滑动列表也卡顿,帮我排查运行时渲染性能",
+    "query": "My Lynx page's first paint is slow and the scrolling list janks — help me debug the runtime render performance.",
     "should_trigger": false
   },
   {
@@ -56,7 +56,7 @@
     "should_trigger": false
   },
   {
-    "query": "帮我把这个 ReactLynx 的 class 组件改写成函数组件 + hooks",
+    "query": "Rewrite this ReactLynx class component into a function component with hooks.",
     "should_trigger": false
   },
   {
@@ -64,7 +64,7 @@
     "should_trigger": false
   },
   {
-    "query": "我想解码/分析 Lynx 的 tasm 二进制,看看 template 文件里的结构和指令是怎么编码的",
+    "query": "I want to decode/analyze the Lynx tasm binary to see how the structures and instructions inside the template file are encoded.",
     "should_trigger": false
   },
   {
@@ -72,7 +72,7 @@
     "should_trigger": false
   },
   {
-    "query": "我想深入查 rsdoctor-data.json 里 tree-shaking 到底保留了哪些模块、有哪些 side-effects 没摇掉,做细粒度模块分析",
+    "query": "I want to dig into rsdoctor-data.json to see exactly which modules tree-shaking retained and which side-effects weren't shaken — a fine-grained per-module analysis.",
     "should_trigger": false
   },
   {
@@ -80,7 +80,7 @@
     "should_trigger": false
   },
   {
-    "query": "Next.js App Router 的 bundle 怎么优化?RSC 和 client component 拆分后首屏 JS 还是太大",
+    "query": "How do I optimize a Next.js App Router bundle? After splitting RSC and client components the first-screen JS is still too big.",
     "should_trigger": false
   },
   {

--- a/packages/skills/rspeedy-bundle-size/package.json
+++ b/packages/skills/rspeedy-bundle-size/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@lynx-js/skill-rspeedy-bundle-size",
+  "version": "0.0.0",
+  "description": "Analyze and reduce the bundle size of rspeedy/Lynx (ReactLynx) apps",
+  "repository": {
+    "url": "https://github.com/lynx-community/skills"
+  },
+  "type": "module",
+  "files": [
+    "SKILL.md",
+    "references"
+  ],
+  "scripts": {},
+  "devDependencies": {},
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/packages/skills/rspeedy-bundle-size/references/assets/gate.awk
+++ b/packages/skills/rspeedy-bundle-size/references/assets/gate.awk
@@ -1,0 +1,53 @@
+# Selective main-thread gate for jsb wrapper functions.
+# Gates ONLY top-level functions whose body delegates to the bridge singleton
+# (references `core.` ) or calls jsb directly (.bridge / NativeModules /
+# getJSModule / GlobalEventEmitter). Pure helpers (env/version/babel-runtime)
+# are left untouched so main-thread render that calls them still works.
+# PREREQUISITE: prettier-expand the input first — `prettier --no-config --write lib.lynx.js`.
+# It gates per-function by LINE; a compact `function f(){...}` body (brace not at end of
+# line) is left as-is with a WARN. Real-tested on one jsb lib: raw 1/77 gated, prettier 77/77.
+# SCOPE LIMIT: only matches TOP-LEVEL `function foo(){}` declarations. jsb that lives in
+# class methods (`foo(){ ... }`) or arrow exports (`const f = () => ...`) is INVISIBLE here.
+# Such a lib will report GATED=0 even though it calls the bridge — so this END warns when the
+# file references jsb APIs anywhere but gated nothing (real-tested miss: a class-method jsb lib
+# gated 0/4 while calling .bridge/getJSModule/NativeModules from class methods). For class/arrow libs,
+# gate via a babel/SWC visitor instead. A bare GATED=0 is NOT proof the lib is jsb-free.
+BEGIN { inf=0; n=0; gated=0; pure=0; filejsb=0 }
+/core\.|\.bridge|NativeModules|getJSModule|GlobalEventEmitter/ { filejsb=1 }
+/^function [A-Za-z_$][A-Za-z0-9_$]*\(/ {
+  if (inf) { flush() }            # defensive: flush a prior unclosed fn
+  inf=1; idx=0; buf[idx++]=$0; sig=$0; jsb=0; next
+}
+inf==1 {
+  buf[idx++]=$0
+  if ($0 ~ /core\.|\.bridge|NativeModules|getJSModule|GlobalEventEmitter/) jsb=1
+  if ($0 ~ /^}/) { flush() }
+  next
+}
+{ print }
+function flush(   i,s,done) {
+  n++
+  if (jsb) {
+    gated++
+    # Insert the guard right after the FIRST line ending in a lone `{` — handles
+    # both K&R (`function f(){`) and Allman (`{` on its own line). If no such line
+    # exists (multi-line signature), emit the function UNCHANGED rather than
+    # corrupt it (the old fallback produced `function f(if(__MAIN_THREAD__)return;`).
+    done=0
+    for (i=0;i<idx;i++) {
+      s=buf[i]
+      if (!done && s ~ /\{[ \t]*$/) { sub(/\{[ \t]*$/, "{if(__MAIN_THREAD__)return;", s); done=1 }
+      print s
+    }
+    if (!done) print "WARN: no `{`-terminated line to gate (multi-line sig?) — left as-is" > "/dev/stderr"
+  } else {
+    pure++
+    for (i=0;i<idx;i++) print buf[i]
+  }
+  inf=0; jsb=0; idx=0
+}
+END {
+  if (inf) flush()
+  print "GATED="gated" PURE_KEPT="pure" TOTAL="n > "/dev/stderr"
+  if (gated==0 && filejsb) print "WARN: file references jsb APIs but GATED=0 — jsb is likely in class methods / arrow functions, which this top-level-`function`-only gate cannot see. Gate via a babel/SWC visitor; do NOT treat GATED=0 as jsb-free." > "/dev/stderr"
+}

--- a/packages/skills/rspeedy-bundle-size/references/assets/mt-cutpoint-analyzer.mjs
+++ b/packages/skills/rspeedy-bundle-size/references/assets/mt-cutpoint-analyzer.mjs
@@ -1,41 +1,89 @@
-import fs from 'fs';
+import fs from 'node:fs';
+
 const src = fs.readFileSync(process.argv[2], 'utf8');
 const HEADER = /"(\(react:(?:main-thread|background)\)\/[^"]+)"\(/g;
-const heads = []; let m;
-while ((m = HEADER.exec(src))) heads.push({ path: m[1], start: m.index });
-const mods = heads.map((h, i) => ({ path: h.path, body: src.slice(h.start, i+1<heads.length?heads[i+1].start:src.length) }));
+const heads = [];
+for (const m of src.matchAll(HEADER))
+  heads.push({ path: m[1], start: m.index });
+const mods = heads.map((h, i) => ({
+  path: h.path,
+  body: src.slice(
+    h.start,
+    i + 1 < heads.length ? heads[i + 1].start : src.length,
+  ),
+}));
 const REQ = /[a-zA-Z_$]\("(\(react:(?:main-thread|background)\)\/[^"]+)"\)/g;
-const isMT = p => p.startsWith('(react:main-thread)');
-const mt = mods.filter(x => isMT(x.path));
-for (const mod of mt) { mod.size = mod.body.length; mod.deps = new Set(); let r; while ((r = REQ.exec(mod.body))) if (isMT(r[1]) && r[1]!==mod.path) mod.deps.add(r[1]); }
+const isMT = (p) => p.startsWith('(react:main-thread)');
+const mt = mods.filter((x) => isMT(x.path));
+for (const mod of mt) {
+  mod.size = mod.body.length;
+  mod.deps = new Set();
+  for (const r of mod.body.matchAll(REQ))
+    if (isMT(r[1]) && r[1] !== mod.path) mod.deps.add(r[1]);
+}
 const importers = new Map();
-for (const mod of mt) for (const d of mod.deps) { if(!importers.has(d)) importers.set(d,new Set()); importers.get(d).add(mod.path); }
+for (const mod of mt)
+  for (const d of mod.deps) {
+    if (!importers.has(d)) importers.set(d, new Set());
+    importers.get(d).add(mod.path);
+  }
 
 // Real package/module path = AFTER the last /node_modules/ (strips the pnpm peer-dep hash dir),
 // else the app/lib source path. Apply signatures to THIS, never the raw pnpm path.
-const real = p => { const s = p.replace('(react:main-thread)/',''); const i = s.lastIndexOf('/node_modules/'); return i>=0 ? s.slice(i+14) : s.replace('../../',''); };
+const real = (p) => {
+  const s = p.replace('(react:main-thread)/', '');
+  const i = s.lastIndexOf('/node_modules/');
+  return i >= 0 ? s.slice(i + 14) : s.replace('../../', '');
+};
+
 // Background-only packages + app-module signatures live in signatures.cjs
 // (overridable per stack / via the internal overlay).
 import signatures from './signatures.cjs';
-const { BG_PACKAGES: BG, BG_APP } = signatures;
-const flag = p => { const r = real(p); return BG.test(r) || (/\/(request|monitor|report|btm|log|tracker)\//i.test('/'+r) && BG_APP.test(r)) || BG_APP.test(r.split('/').pop()); };
-const short = p => real(p);
-const bg = new Set(mt.filter(x => flag(x.path)).map(x=>x.path));
 
-let pureBg=0, boundary=0; const bnd=[];
+const { BG_PACKAGES: BG, BG_APP } = signatures;
+const flag = (p) => {
+  const r = real(p);
+  return (
+    BG.test(r) ||
+    (/\/(request|monitor|report|btm|log|tracker)\//i.test(`/${r}`) &&
+      BG_APP.test(r)) ||
+    BG_APP.test(r.split('/').pop())
+  );
+};
+const short = (p) => real(p);
+const bg = new Set(mt.filter((x) => flag(x.path)).map((x) => x.path));
+
+let pureBg = 0,
+  boundary = 0;
+const bnd = [];
 for (const p of bg) {
-  const imps = [...(importers.get(p)||[])];
-  const renderImps = imps.filter(i => !bg.has(i));
-  const mod = mt.find(x=>x.path===p);
-  if (renderImps.length===0) pureBg += mod.size;           // only bg importers → free shake
-  else { boundary += mod.size; bnd.push({p, size:mod.size, renderImps}); }  // render imports it → cut here
+  const imps = [...(importers.get(p) || [])];
+  const renderImps = imps.filter((i) => !bg.has(i));
+  const mod = mt.find((x) => x.path === p);
+  if (renderImps.length === 0)
+    pureBg += mod.size; // only bg importers → free shake
+  else {
+    boundary += mod.size;
+    bnd.push({ p, size: mod.size, renderImps });
+  } // render imports it → cut here
 }
-console.log(`MT total: ${(mt.reduce((a,b)=>a+b.size,0)/1024).toFixed(0)} kB`);
-console.log(`background-only modules in MT: ${bg.size}, ${([...bg].reduce((a,p)=>a+mt.find(x=>x.path===p).size,0)/1024).toFixed(1)} kB`);
-console.log(`  • pure-background subtree (only bg importers → shakes for free once boundary cut): ${(pureBg/1024).toFixed(1)} kB`);
-console.log(`  • boundary modules (a RENDER module imports them → the cut points): ${(boundary/1024).toFixed(1)} kB\n`);
-console.log(`=== CUT POINTS: render module → background-only module (guard/split these) ===`);
-for (const b of bnd.sort((a,b)=>b.size-a.size).slice(0,18)) {
-  console.log(`${(b.size/1024).toFixed(1).padStart(6)}kB  ${short(b.p)}`);
-  for (const ri of b.renderImps.slice(0,2)) console.log(`         ← ${short(ri)}`);
+console.log(
+  `MT total: ${(mt.reduce((a, b) => a + b.size, 0) / 1024).toFixed(0)} kB`,
+);
+console.log(
+  `background-only modules in MT: ${bg.size}, ${([...bg].reduce((a, p) => a + mt.find((x) => x.path === p).size, 0) / 1024).toFixed(1)} kB`,
+);
+console.log(
+  `  • pure-background subtree (only bg importers → shakes for free once boundary cut): ${(pureBg / 1024).toFixed(1)} kB`,
+);
+console.log(
+  `  • boundary modules (a RENDER module imports them → the cut points): ${(boundary / 1024).toFixed(1)} kB\n`,
+);
+console.log(
+  `=== CUT POINTS: render module → background-only module (guard/split these) ===`,
+);
+for (const b of bnd.sort((a, b) => b.size - a.size).slice(0, 18)) {
+  console.log(`${(b.size / 1024).toFixed(1).padStart(6)}kB  ${short(b.p)}`);
+  for (const ri of b.renderImps.slice(0, 2))
+    console.log(`         ← ${short(ri)}`);
 }

--- a/packages/skills/rspeedy-bundle-size/references/assets/mt-cutpoint-analyzer.mjs
+++ b/packages/skills/rspeedy-bundle-size/references/assets/mt-cutpoint-analyzer.mjs
@@ -1,0 +1,41 @@
+import fs from 'fs';
+const src = fs.readFileSync(process.argv[2], 'utf8');
+const HEADER = /"(\(react:(?:main-thread|background)\)\/[^"]+)"\(/g;
+const heads = []; let m;
+while ((m = HEADER.exec(src))) heads.push({ path: m[1], start: m.index });
+const mods = heads.map((h, i) => ({ path: h.path, body: src.slice(h.start, i+1<heads.length?heads[i+1].start:src.length) }));
+const REQ = /[a-zA-Z_$]\("(\(react:(?:main-thread|background)\)\/[^"]+)"\)/g;
+const isMT = p => p.startsWith('(react:main-thread)');
+const mt = mods.filter(x => isMT(x.path));
+for (const mod of mt) { mod.size = mod.body.length; mod.deps = new Set(); let r; while ((r = REQ.exec(mod.body))) if (isMT(r[1]) && r[1]!==mod.path) mod.deps.add(r[1]); }
+const importers = new Map();
+for (const mod of mt) for (const d of mod.deps) { if(!importers.has(d)) importers.set(d,new Set()); importers.get(d).add(mod.path); }
+
+// Real package/module path = AFTER the last /node_modules/ (strips the pnpm peer-dep hash dir),
+// else the app/lib source path. Apply signatures to THIS, never the raw pnpm path.
+const real = p => { const s = p.replace('(react:main-thread)/',''); const i = s.lastIndexOf('/node_modules/'); return i>=0 ? s.slice(i+14) : s.replace('../../',''); };
+// Background-only packages + app-module signatures live in signatures.cjs
+// (overridable per stack / via the internal overlay).
+import signatures from './signatures.cjs';
+const { BG_PACKAGES: BG, BG_APP } = signatures;
+const flag = p => { const r = real(p); return BG.test(r) || (/\/(request|monitor|report|btm|log|tracker)\//i.test('/'+r) && BG_APP.test(r)) || BG_APP.test(r.split('/').pop()); };
+const short = p => real(p);
+const bg = new Set(mt.filter(x => flag(x.path)).map(x=>x.path));
+
+let pureBg=0, boundary=0; const bnd=[];
+for (const p of bg) {
+  const imps = [...(importers.get(p)||[])];
+  const renderImps = imps.filter(i => !bg.has(i));
+  const mod = mt.find(x=>x.path===p);
+  if (renderImps.length===0) pureBg += mod.size;           // only bg importers → free shake
+  else { boundary += mod.size; bnd.push({p, size:mod.size, renderImps}); }  // render imports it → cut here
+}
+console.log(`MT total: ${(mt.reduce((a,b)=>a+b.size,0)/1024).toFixed(0)} kB`);
+console.log(`background-only modules in MT: ${bg.size}, ${([...bg].reduce((a,p)=>a+mt.find(x=>x.path===p).size,0)/1024).toFixed(1)} kB`);
+console.log(`  • pure-background subtree (only bg importers → shakes for free once boundary cut): ${(pureBg/1024).toFixed(1)} kB`);
+console.log(`  • boundary modules (a RENDER module imports them → the cut points): ${(boundary/1024).toFixed(1)} kB\n`);
+console.log(`=== CUT POINTS: render module → background-only module (guard/split these) ===`);
+for (const b of bnd.sort((a,b)=>b.size-a.size).slice(0,18)) {
+  console.log(`${(b.size/1024).toFixed(1).padStart(6)}kB  ${short(b.p)}`);
+  for (const ri of b.renderImps.slice(0,2)) console.log(`         ← ${short(ri)}`);
+}

--- a/packages/skills/rspeedy-bundle-size/references/assets/mt-cutpoint-analyzer.mjs
+++ b/packages/skills/rspeedy-bundle-size/references/assets/mt-cutpoint-analyzer.mjs
@@ -1,3 +1,7 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
 import fs from 'node:fs';
 
 const src = fs.readFileSync(process.argv[2], 'utf8');

--- a/packages/skills/rspeedy-bundle-size/references/assets/mt-leak-analyzer.mjs
+++ b/packages/skills/rspeedy-bundle-size/references/assets/mt-leak-analyzer.mjs
@@ -1,6 +1,7 @@
 // Import-chain analysis of the de-concat main-thread.js:
 // list modules, sizes, background-only flags, and importer edges (who pulls each module).
-import fs from 'fs';
+import fs from 'node:fs';
+
 const file = process.argv[2];
 const src = fs.readFileSync(file, 'utf8');
 
@@ -8,25 +9,28 @@ const src = fs.readFileSync(file, 'utf8');
 // Distinguish from __webpack_require__("path") by requiring an OPEN paren right after the quote.
 const HEADER = /"(\(react:(?:main-thread|background)\)\/[^"]+)"\(/g;
 const heads = [];
-let m;
-while ((m = HEADER.exec(src))) heads.push({ path: m[1], start: m.index });
+for (const m of src.matchAll(HEADER))
+  heads.push({ path: m[1], start: m.index });
 const mods = heads.map((h, i) => ({
   path: h.path,
-  body: src.slice(h.start, i + 1 < heads.length ? heads[i + 1].start : src.length),
+  body: src.slice(
+    h.start,
+    i + 1 < heads.length ? heads[i + 1].start : src.length,
+  ),
 }));
 
 // Background-only signatures (basename + content) live in signatures.cjs
 // (overridable per stack / via the internal overlay).
 import signatures from './signatures.cjs';
+
 const { BG_NAME, BG_CONTENT } = signatures;
 const REQ = /[a-zA-Z_$]\("(\(react:(?:main-thread|background)\)\/[^"]+)"\)/g;
 
-const byPath = new Map(mods.map(x => [x.path, x]));
+const _byPath = new Map(mods.map((x) => [x.path, x]));
 const importers = new Map(); // path -> Set of modules that require it
 for (const mod of mods) {
-  let r;
   const seen = new Set();
-  while ((r = REQ.exec(mod.body))) {
+  for (const r of mod.body.matchAll(REQ)) {
     const dep = r[1];
     if (dep === mod.path) continue;
     if (!importers.has(dep)) importers.set(dep, new Set());
@@ -40,16 +44,30 @@ for (const mod of mods) {
   mod.bgContent = BG_CONTENT.test(mod.body);
 }
 
-const isMT = p => p.startsWith('(react:main-thread)');
-const mtMods = mods.filter(x => isMT(x.path));
-console.log(`=== main-thread modules: ${mtMods.length}, total ${(mtMods.reduce((a,b)=>a+b.size,0)/1024).toFixed(0)} kB ===`);
+const isMT = (p) => p.startsWith('(react:main-thread)');
+const mtMods = mods.filter((x) => isMT(x.path));
+console.log(
+  `=== main-thread modules: ${mtMods.length}, total ${(mtMods.reduce((a, b) => a + b.size, 0) / 1024).toFixed(0)} kB ===`,
+);
 
 // Background-only modules that LEAKED into main-thread, by size.
-const leaks = mtMods.filter(x => x.bgName || x.bgContent).sort((a,b)=>b.size-a.size);
-console.log(`\n=== background-only modules in MAIN-THREAD (top 30 by size) ===`);
-for (const l of leaks.slice(0,30)) {
-  const imps = [...(importers.get(l.path)||[])].map(p=>p.replace('(react:main-thread)/','')).slice(0,3);
-  console.log(`${(l.size/1024).toFixed(1).padStart(7)}kB ${l.bgContent?'C':' '}${l.bgName?'N':' '}  ${l.path.replace('(react:main-thread)/','')}`);
-  console.log(`          ← ${imps.join(' | ')||'(no MT importer — entry/root)'}`);
+const leaks = mtMods
+  .filter((x) => x.bgName || x.bgContent)
+  .sort((a, b) => b.size - a.size);
+console.log(
+  `\n=== background-only modules in MAIN-THREAD (top 30 by size) ===`,
+);
+for (const l of leaks.slice(0, 30)) {
+  const imps = [...(importers.get(l.path) || [])]
+    .map((p) => p.replace('(react:main-thread)/', ''))
+    .slice(0, 3);
+  console.log(
+    `${(l.size / 1024).toFixed(1).padStart(7)}kB ${l.bgContent ? 'C' : ' '}${l.bgName ? 'N' : ' '}  ${l.path.replace('(react:main-thread)/', '')}`,
+  );
+  console.log(
+    `          ← ${imps.join(' | ') || '(no MT importer — entry/root)'}`,
+  );
 }
-console.log(`\nleak total: ${(leaks.reduce((a,b)=>a+b.size,0)/1024).toFixed(1)} kB across ${leaks.length} modules`);
+console.log(
+  `\nleak total: ${(leaks.reduce((a, b) => a + b.size, 0) / 1024).toFixed(1)} kB across ${leaks.length} modules`,
+);

--- a/packages/skills/rspeedy-bundle-size/references/assets/mt-leak-analyzer.mjs
+++ b/packages/skills/rspeedy-bundle-size/references/assets/mt-leak-analyzer.mjs
@@ -1,0 +1,55 @@
+// Import-chain analysis of the de-concat main-thread.js:
+// list modules, sizes, background-only flags, and importer edges (who pulls each module).
+import fs from 'fs';
+const file = process.argv[2];
+const src = fs.readFileSync(file, 'utf8');
+
+// Split into modules by the rspack module header: "(react:...)/path"( ...args... ) {
+// Distinguish from __webpack_require__("path") by requiring an OPEN paren right after the quote.
+const HEADER = /"(\(react:(?:main-thread|background)\)\/[^"]+)"\(/g;
+const heads = [];
+let m;
+while ((m = HEADER.exec(src))) heads.push({ path: m[1], start: m.index });
+const mods = heads.map((h, i) => ({
+  path: h.path,
+  body: src.slice(h.start, i + 1 < heads.length ? heads[i + 1].start : src.length),
+}));
+
+// Background-only signatures (basename + content) live in signatures.cjs
+// (overridable per stack / via the internal overlay).
+import signatures from './signatures.cjs';
+const { BG_NAME, BG_CONTENT } = signatures;
+const REQ = /[a-zA-Z_$]\("(\(react:(?:main-thread|background)\)\/[^"]+)"\)/g;
+
+const byPath = new Map(mods.map(x => [x.path, x]));
+const importers = new Map(); // path -> Set of modules that require it
+for (const mod of mods) {
+  let r;
+  const seen = new Set();
+  while ((r = REQ.exec(mod.body))) {
+    const dep = r[1];
+    if (dep === mod.path) continue;
+    if (!importers.has(dep)) importers.set(dep, new Set());
+    importers.get(dep).add(mod.path);
+    seen.add(dep);
+  }
+  mod.deps = seen;
+  mod.size = mod.body.length;
+  const base = mod.path.split('/').pop();
+  mod.bgName = BG_NAME.test(base);
+  mod.bgContent = BG_CONTENT.test(mod.body);
+}
+
+const isMT = p => p.startsWith('(react:main-thread)');
+const mtMods = mods.filter(x => isMT(x.path));
+console.log(`=== main-thread modules: ${mtMods.length}, total ${(mtMods.reduce((a,b)=>a+b.size,0)/1024).toFixed(0)} kB ===`);
+
+// Background-only modules that LEAKED into main-thread, by size.
+const leaks = mtMods.filter(x => x.bgName || x.bgContent).sort((a,b)=>b.size-a.size);
+console.log(`\n=== background-only modules in MAIN-THREAD (top 30 by size) ===`);
+for (const l of leaks.slice(0,30)) {
+  const imps = [...(importers.get(l.path)||[])].map(p=>p.replace('(react:main-thread)/','')).slice(0,3);
+  console.log(`${(l.size/1024).toFixed(1).padStart(7)}kB ${l.bgContent?'C':' '}${l.bgName?'N':' '}  ${l.path.replace('(react:main-thread)/','')}`);
+  console.log(`          ← ${imps.join(' | ')||'(no MT importer — entry/root)'}`);
+}
+console.log(`\nleak total: ${(leaks.reduce((a,b)=>a+b.size,0)/1024).toFixed(1)} kB across ${leaks.length} modules`);

--- a/packages/skills/rspeedy-bundle-size/references/assets/mt-leak-analyzer.mjs
+++ b/packages/skills/rspeedy-bundle-size/references/assets/mt-leak-analyzer.mjs
@@ -1,3 +1,7 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
 // Import-chain analysis of the de-concat main-thread.js:
 // list modules, sizes, background-only flags, and importer edges (who pulls each module).
 import fs from 'node:fs';
@@ -26,7 +30,6 @@ import signatures from './signatures.cjs';
 const { BG_NAME, BG_CONTENT } = signatures;
 const REQ = /[a-zA-Z_$]\("(\(react:(?:main-thread|background)\)\/[^"]+)"\)/g;
 
-const _byPath = new Map(mods.map((x) => [x.path, x]));
 const importers = new Map(); // path -> Set of modules that require it
 for (const mod of mods) {
   const seen = new Set();

--- a/packages/skills/rspeedy-bundle-size/references/assets/plugin-strip-mt-telemetry.ts
+++ b/packages/skills/rspeedy-bundle-size/references/assets/plugin-strip-mt-telemetry.ts
@@ -13,7 +13,10 @@ export function pluginStripMtTelemetry(): RsbuildPlugin {
     setup(api) {
       api.modifyBundlerChain({
         order: 'post',
-        handler: (chain, util = {} as { CHAIN_ID?: any }) => {
+        handler: (
+          chain,
+          util = {} as { CHAIN_ID?: Record<string, Record<string, string>> },
+        ) => {
           const { CHAIN_ID } = util || {};
           const jsRule = chain.module.rule(CHAIN_ID?.RULE?.JS || '');
           // The chain keys ('react:main-thread', CHAIN_ID.RULE.JS, CHAIN_ID.USE.SWC)
@@ -28,8 +31,13 @@ export function pluginStripMtTelemetry(): RsbuildPlugin {
           }
           const oneOfRule = jsRule.oneOf(MAIN_THREAD_LAYER);
           const swcUse = CHAIN_ID?.USE?.SWC || '';
-          const loaderPath = path.resolve(__dirname, './strip-mt-telemetry-loader.cjs');
-          const useChain = oneOfRule.use('strip-mt-telemetry').loader(loaderPath);
+          const loaderPath = path.resolve(
+            __dirname,
+            './strip-mt-telemetry-loader.cjs',
+          );
+          const useChain = oneOfRule
+            .use('strip-mt-telemetry')
+            .loader(loaderPath);
           if (swcUse && oneOfRule.uses.has(swcUse)) useChain.before(swcUse);
         },
       });

--- a/packages/skills/rspeedy-bundle-size/references/assets/plugin-strip-mt-telemetry.ts
+++ b/packages/skills/rspeedy-bundle-size/references/assets/plugin-strip-mt-telemetry.ts
@@ -1,0 +1,38 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type { RsbuildPlugin } from '@lynx-js/rspeedy';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const MAIN_THREAD_LAYER = 'react:main-thread';
+
+// Registers the telemetry-stripping loader on the main-thread layer ONLY.
+// Runs after swc (placed `.before(swc)` in the use array; loaders run right-to-left).
+export function pluginStripMtTelemetry(): RsbuildPlugin {
+  return {
+    name: 'lynx:strip-mt-telemetry',
+    setup(api) {
+      api.modifyBundlerChain({
+        order: 'post',
+        handler: (chain, util = {} as { CHAIN_ID?: any }) => {
+          const { CHAIN_ID } = util || {};
+          const jsRule = chain.module.rule(CHAIN_ID?.RULE?.JS || '');
+          // The chain keys ('react:main-thread', CHAIN_ID.RULE.JS, CHAIN_ID.USE.SWC)
+          // must match the installed rspeedy version. If they don't, this guard fires
+          // and the loader silently does NOTHING — so warn rather than no-op in silence
+          // (don't trust a green build that stripped zero calls; verify the layer key).
+          if (!jsRule.oneOfs.has(MAIN_THREAD_LAYER)) {
+            console.warn(
+              `[strip-mt-telemetry] oneOf "${MAIN_THREAD_LAYER}" not found on the JS rule — loader NOT applied. Verify the rspeedy chain layer key for your version.`,
+            );
+            return;
+          }
+          const oneOfRule = jsRule.oneOf(MAIN_THREAD_LAYER);
+          const swcUse = CHAIN_ID?.USE?.SWC || '';
+          const loaderPath = path.resolve(__dirname, './strip-mt-telemetry-loader.cjs');
+          const useChain = oneOfRule.use('strip-mt-telemetry').loader(loaderPath);
+          if (swcUse && oneOfRule.uses.has(swcUse)) useChain.before(swcUse);
+        },
+      });
+    },
+  };
+}

--- a/packages/skills/rspeedy-bundle-size/references/assets/plugin-strip-mt-telemetry.ts
+++ b/packages/skills/rspeedy-bundle-size/references/assets/plugin-strip-mt-telemetry.ts
@@ -1,3 +1,7 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import type { RsbuildPlugin } from '@lynx-js/rspeedy';

--- a/packages/skills/rspeedy-bundle-size/references/assets/scan-levers.mjs
+++ b/packages/skills/rspeedy-bundle-size/references/assets/scan-levers.mjs
@@ -1,0 +1,86 @@
+#!/usr/bin/env node
+/**
+ * Cross-project bundle-lever TRIAGE scanner (source-only, no build).
+ *
+ * The skill is measure-first per project — but you can't build a whole fleet to
+ * decide where to look. This scans the *source* of one or more project dirs for
+ * the cheap precursors of the three size levers, so you can rank which projects
+ * deserve a real build+measure. A hit means "measure here", NOT "confirmed bloat".
+ * Read references/cross-project-triage.md for how to interpret + its traps.
+ *
+ * Usage:
+ *   node scan-levers.mjs <projectDir> [<projectDir> ...]   # scan given dirs
+ *   node scan-levers.mjs --glob <reposRoot>                # scan each child dir
+ *   node scan-levers.mjs ... --json out.json               # also write full JSON
+ */
+import { existsSync, readFileSync, readdirSync, statSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+
+// Background-only signatures live in signatures.cjs (overridable per stack / via the
+// internal overlay). See that file for the jsb-backed-vs-console caveat.
+import signatures from './signatures.cjs';
+const { LEAK_PATTERNS } = signatures;
+const GUARD_PATTERNS = [/__BACKGROUND__/, /__MAIN_THREAD__/, /__LEPUS__/, /__JS__/, /['"]background[ -]only['"]/];
+const SRC_EXT = new Set(['.ts', '.tsx', '.js', '.jsx', '.mts', '.cts']);
+const IMG_EXT = new Set(['.png', '.jpg', '.jpeg', '.gif', '.webp', '.svg']);
+const SKIP_DIR = new Set(['node_modules', 'dist', 'output', 'lynx_output', '.rspeedy', '.git', 'build', 'coverage', '__tests__', 'test', 'tests']);
+const BIG_IMG = 50 * 1024, BIG_B64 = 5000;
+
+function walk(dir, depth, onFile) {
+  if (depth > 12) return;
+  let ents; try { ents = readdirSync(dir, { withFileTypes: true }); } catch { return; }
+  for (const e of ents) {
+    if (e.name.startsWith('.') && e.name !== '.') continue;
+    if (SKIP_DIR.has(e.name)) continue;
+    const full = path.join(dir, e.name);
+    if (e.isDirectory()) walk(full, depth + 1, onFile);
+    else if (e.isFile()) onFile(full);
+  }
+}
+
+function scanProject(subdir) {
+  const leakHits = {};
+  const leakFiles = new Set();
+  let guardedFiles = 0, scannedSrc = 0, b64Count = 0, b64Bytes = 0, bigImgCount = 0, bigImgBytes = 0;
+  walk(subdir, 0, (full) => {
+    const ext = path.extname(full);
+    if (IMG_EXT.has(ext)) { let sz = 0; try { sz = statSync(full).size; } catch {} if (sz >= BIG_IMG) { bigImgCount++; bigImgBytes += sz; } return; }
+    if (!SRC_EXT.has(ext)) return;
+    let src; try { src = readFileSync(full, 'utf8'); } catch { return; }
+    if (src.length > 4 * 1024 * 1024) return;
+    scannedSrc++;
+    let fileLeaks = false;
+    for (const [name, re] of LEAK_PATTERNS) if (re.test(src)) { leakHits[name] = (leakHits[name] || 0) + 1; fileLeaks = true; }
+    if (fileLeaks) { leakFiles.add(full); if (GUARD_PATTERNS.some((g) => g.test(src))) guardedFiles++; }
+    for (const m of src.matchAll(/data:[^;]+;base64,([A-Za-z0-9+/=]{1000,})/g)) if (m[1].length >= BIG_B64) { b64Count++; b64Bytes += m[1].length; }
+  });
+  let sideEffects = 'missing';
+  try { const j = JSON.parse(readFileSync(path.join(subdir, 'package.json'), 'utf8')); if ('sideEffects' in j) sideEffects = JSON.stringify(j.sideEffects); } catch {}
+  return {
+    dir: subdir, scannedSrc, leakFiles: leakFiles.size, guardedFiles,
+    guardRatio: leakFiles.size ? +(guardedFiles / leakFiles.size).toFixed(2) : null,
+    leakHits, sideEffects,
+    b64Count, b64KB: +(b64Bytes / 1024).toFixed(1), bigImgCount, bigImgKB: +(bigImgBytes / 1024).toFixed(1),
+  };
+}
+
+const argv = process.argv.slice(2);
+const jsonIdx = argv.indexOf('--json');
+const jsonOut = jsonIdx >= 0 ? argv[jsonIdx + 1] : null;
+let dirs = argv.filter((a, i) => !a.startsWith('--') && argv[i - 1] !== '--json');
+const globIdx = argv.indexOf('--glob');
+if (globIdx >= 0) {
+  const root = argv[globIdx + 1];
+  dirs = readdirSync(root, { withFileTypes: true }).filter((e) => e.isDirectory()).map((e) => path.join(root, e.name));
+}
+if (!dirs.length) { console.error('usage: scan-levers.mjs <projectDir>... | --glob <reposRoot> [--json out.json]'); process.exit(1); }
+
+const results = dirs.map(scanProject);
+const ranked = [...results].filter((r) => r.leakFiles > 0).sort((a, b) => (a.guardRatio ?? 1) - (b.guardRatio ?? 1) || b.leakFiles - a.leakFiles);
+const leakFreq = {};
+for (const r of results) for (const k of Object.keys(r.leakHits)) leakFreq[k] = (leakFreq[k] || 0) + 1;
+console.log('=== ranked leak candidates (low guardRatio first) ===');
+for (const r of ranked.slice(0, 30)) console.log(`${path.basename(r.dir).slice(0, 36).padEnd(36)} leakFiles=${String(r.leakFiles).padStart(3)} guard=${r.guardRatio} bigImg=${r.bigImgCount} sideFx=${r.sideEffects}`);
+console.log('\n=== leak-API frequency (projects) ===', JSON.stringify(Object.fromEntries(Object.entries(leakFreq).sort((a, b) => b[1] - a[1]))));
+console.log(`projects=${results.length} withLeak=${results.filter((r) => r.leakFiles > 0).length} missingSideEffects=${results.filter((r) => r.sideEffects === 'missing').length}`);
+if (jsonOut) { writeFileSync(jsonOut, JSON.stringify({ results, leakFreq }, null, 2)); console.log('wrote ' + jsonOut); }

--- a/packages/skills/rspeedy-bundle-size/references/assets/scan-levers.mjs
+++ b/packages/skills/rspeedy-bundle-size/references/assets/scan-levers.mjs
@@ -1,4 +1,7 @@
 #!/usr/bin/env node
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
 /**
  * Cross-project bundle-lever TRIAGE scanner (source-only, no build).
  *

--- a/packages/skills/rspeedy-bundle-size/references/assets/scan-levers.mjs
+++ b/packages/skills/rspeedy-bundle-size/references/assets/scan-levers.mjs
@@ -13,22 +13,47 @@
  *   node scan-levers.mjs --glob <reposRoot>                # scan each child dir
  *   node scan-levers.mjs ... --json out.json               # also write full JSON
  */
-import { existsSync, readFileSync, readdirSync, statSync, writeFileSync } from 'node:fs';
+import { readdirSync, readFileSync, statSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 
 // Background-only signatures live in signatures.cjs (overridable per stack / via the
 // internal overlay). See that file for the jsb-backed-vs-console caveat.
 import signatures from './signatures.cjs';
+
 const { LEAK_PATTERNS } = signatures;
-const GUARD_PATTERNS = [/__BACKGROUND__/, /__MAIN_THREAD__/, /__LEPUS__/, /__JS__/, /['"]background[ -]only['"]/];
+const GUARD_PATTERNS = [
+  /__BACKGROUND__/,
+  /__MAIN_THREAD__/,
+  /__LEPUS__/,
+  /__JS__/,
+  /['"]background[ -]only['"]/,
+];
 const SRC_EXT = new Set(['.ts', '.tsx', '.js', '.jsx', '.mts', '.cts']);
 const IMG_EXT = new Set(['.png', '.jpg', '.jpeg', '.gif', '.webp', '.svg']);
-const SKIP_DIR = new Set(['node_modules', 'dist', 'output', 'lynx_output', '.rspeedy', '.git', 'build', 'coverage', '__tests__', 'test', 'tests']);
-const BIG_IMG = 50 * 1024, BIG_B64 = 5000;
+const SKIP_DIR = new Set([
+  'node_modules',
+  'dist',
+  'output',
+  'lynx_output',
+  '.rspeedy',
+  '.git',
+  'build',
+  'coverage',
+  '__tests__',
+  'test',
+  'tests',
+]);
+const BIG_IMG = 50 * 1024,
+  BIG_B64 = 5000;
 
 function walk(dir, depth, onFile) {
   if (depth > 12) return;
-  let ents; try { ents = readdirSync(dir, { withFileTypes: true }); } catch { return; }
+  let ents;
+  try {
+    ents = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
   for (const e of ents) {
     if (e.name.startsWith('.') && e.name !== '.') continue;
     if (SKIP_DIR.has(e.name)) continue;
@@ -41,46 +66,119 @@ function walk(dir, depth, onFile) {
 function scanProject(subdir) {
   const leakHits = {};
   const leakFiles = new Set();
-  let guardedFiles = 0, scannedSrc = 0, b64Count = 0, b64Bytes = 0, bigImgCount = 0, bigImgBytes = 0;
+  let guardedFiles = 0,
+    scannedSrc = 0,
+    b64Count = 0,
+    b64Bytes = 0,
+    bigImgCount = 0,
+    bigImgBytes = 0;
   walk(subdir, 0, (full) => {
     const ext = path.extname(full);
-    if (IMG_EXT.has(ext)) { let sz = 0; try { sz = statSync(full).size; } catch {} if (sz >= BIG_IMG) { bigImgCount++; bigImgBytes += sz; } return; }
+    if (IMG_EXT.has(ext)) {
+      let sz = 0;
+      try {
+        sz = statSync(full).size;
+      } catch {}
+      if (sz >= BIG_IMG) {
+        bigImgCount++;
+        bigImgBytes += sz;
+      }
+      return;
+    }
     if (!SRC_EXT.has(ext)) return;
-    let src; try { src = readFileSync(full, 'utf8'); } catch { return; }
+    let src;
+    try {
+      src = readFileSync(full, 'utf8');
+    } catch {
+      return;
+    }
     if (src.length > 4 * 1024 * 1024) return;
     scannedSrc++;
     let fileLeaks = false;
-    for (const [name, re] of LEAK_PATTERNS) if (re.test(src)) { leakHits[name] = (leakHits[name] || 0) + 1; fileLeaks = true; }
-    if (fileLeaks) { leakFiles.add(full); if (GUARD_PATTERNS.some((g) => g.test(src))) guardedFiles++; }
-    for (const m of src.matchAll(/data:[^;]+;base64,([A-Za-z0-9+/=]{1000,})/g)) if (m[1].length >= BIG_B64) { b64Count++; b64Bytes += m[1].length; }
+    for (const [name, re] of LEAK_PATTERNS)
+      if (re.test(src)) {
+        leakHits[name] = (leakHits[name] || 0) + 1;
+        fileLeaks = true;
+      }
+    if (fileLeaks) {
+      leakFiles.add(full);
+      if (GUARD_PATTERNS.some((g) => g.test(src))) guardedFiles++;
+    }
+    for (const m of src.matchAll(/data:[^;]+;base64,([A-Za-z0-9+/=]{1000,})/g))
+      if (m[1].length >= BIG_B64) {
+        b64Count++;
+        b64Bytes += m[1].length;
+      }
   });
   let sideEffects = 'missing';
-  try { const j = JSON.parse(readFileSync(path.join(subdir, 'package.json'), 'utf8')); if ('sideEffects' in j) sideEffects = JSON.stringify(j.sideEffects); } catch {}
+  try {
+    const j = JSON.parse(
+      readFileSync(path.join(subdir, 'package.json'), 'utf8'),
+    );
+    if ('sideEffects' in j) sideEffects = JSON.stringify(j.sideEffects);
+  } catch {}
   return {
-    dir: subdir, scannedSrc, leakFiles: leakFiles.size, guardedFiles,
-    guardRatio: leakFiles.size ? +(guardedFiles / leakFiles.size).toFixed(2) : null,
-    leakHits, sideEffects,
-    b64Count, b64KB: +(b64Bytes / 1024).toFixed(1), bigImgCount, bigImgKB: +(bigImgBytes / 1024).toFixed(1),
+    dir: subdir,
+    scannedSrc,
+    leakFiles: leakFiles.size,
+    guardedFiles,
+    guardRatio: leakFiles.size
+      ? +(guardedFiles / leakFiles.size).toFixed(2)
+      : null,
+    leakHits,
+    sideEffects,
+    b64Count,
+    b64KB: +(b64Bytes / 1024).toFixed(1),
+    bigImgCount,
+    bigImgKB: +(bigImgBytes / 1024).toFixed(1),
   };
 }
 
 const argv = process.argv.slice(2);
 const jsonIdx = argv.indexOf('--json');
 const jsonOut = jsonIdx >= 0 ? argv[jsonIdx + 1] : null;
-let dirs = argv.filter((a, i) => !a.startsWith('--') && argv[i - 1] !== '--json');
+let dirs = argv.filter(
+  (a, i) => !a.startsWith('--') && argv[i - 1] !== '--json',
+);
 const globIdx = argv.indexOf('--glob');
 if (globIdx >= 0) {
   const root = argv[globIdx + 1];
-  dirs = readdirSync(root, { withFileTypes: true }).filter((e) => e.isDirectory()).map((e) => path.join(root, e.name));
+  dirs = readdirSync(root, { withFileTypes: true })
+    .filter((e) => e.isDirectory())
+    .map((e) => path.join(root, e.name));
 }
-if (!dirs.length) { console.error('usage: scan-levers.mjs <projectDir>... | --glob <reposRoot> [--json out.json]'); process.exit(1); }
+if (!dirs.length) {
+  console.error(
+    'usage: scan-levers.mjs <projectDir>... | --glob <reposRoot> [--json out.json]',
+  );
+  process.exit(1);
+}
 
 const results = dirs.map(scanProject);
-const ranked = [...results].filter((r) => r.leakFiles > 0).sort((a, b) => (a.guardRatio ?? 1) - (b.guardRatio ?? 1) || b.leakFiles - a.leakFiles);
+const ranked = [...results]
+  .filter((r) => r.leakFiles > 0)
+  .sort(
+    (a, b) =>
+      (a.guardRatio ?? 1) - (b.guardRatio ?? 1) || b.leakFiles - a.leakFiles,
+  );
 const leakFreq = {};
-for (const r of results) for (const k of Object.keys(r.leakHits)) leakFreq[k] = (leakFreq[k] || 0) + 1;
+for (const r of results)
+  for (const k of Object.keys(r.leakHits)) leakFreq[k] = (leakFreq[k] || 0) + 1;
 console.log('=== ranked leak candidates (low guardRatio first) ===');
-for (const r of ranked.slice(0, 30)) console.log(`${path.basename(r.dir).slice(0, 36).padEnd(36)} leakFiles=${String(r.leakFiles).padStart(3)} guard=${r.guardRatio} bigImg=${r.bigImgCount} sideFx=${r.sideEffects}`);
-console.log('\n=== leak-API frequency (projects) ===', JSON.stringify(Object.fromEntries(Object.entries(leakFreq).sort((a, b) => b[1] - a[1]))));
-console.log(`projects=${results.length} withLeak=${results.filter((r) => r.leakFiles > 0).length} missingSideEffects=${results.filter((r) => r.sideEffects === 'missing').length}`);
-if (jsonOut) { writeFileSync(jsonOut, JSON.stringify({ results, leakFreq }, null, 2)); console.log('wrote ' + jsonOut); }
+for (const r of ranked.slice(0, 30))
+  console.log(
+    `${path.basename(r.dir).slice(0, 36).padEnd(36)} leakFiles=${String(r.leakFiles).padStart(3)} guard=${r.guardRatio} bigImg=${r.bigImgCount} sideFx=${r.sideEffects}`,
+  );
+console.log(
+  '\n=== leak-API frequency (projects) ===',
+  JSON.stringify(
+    Object.fromEntries(Object.entries(leakFreq).sort((a, b) => b[1] - a[1])),
+  ),
+);
+console.log(
+  `projects=${results.length} withLeak=${results.filter((r) => r.leakFiles > 0).length} missingSideEffects=${results.filter((r) => r.sideEffects === 'missing').length}`,
+);
+if (jsonOut) {
+  writeFileSync(jsonOut, JSON.stringify({ results, leakFreq }, null, 2));
+  console.log(`wrote ${jsonOut}`);
+}

--- a/packages/skills/rspeedy-bundle-size/references/assets/signatures.cjs
+++ b/packages/skills/rspeedy-bundle-size/references/assets/signatures.cjs
@@ -20,19 +20,25 @@ module.exports = {
     ['NativeModules', /\bNativeModules\b/],
     ['getJSModule', /getJSModule\s*\(/],
     ['jsb.bridge', /\.bridge\.|\bjsbCall\b|\brequestAdapter\b/],
-    ['nativeEvents', /\b(GlobalEventEmitter|subscribeEvent|addGlobalEventListener)\b/],
+    [
+      'nativeEvents',
+      /\b(GlobalEventEmitter|subscribeEvent|addGlobalEventListener)\b/,
+    ],
     // monitor / telemetry — background-only ONLY when jsb-backed (customize these)
     ['monitor', /\b(reportMonitor|hybridMonitor)\b/],
     ['telemetry', /\.(reportEvent|reportError|logEvent|track)\s*\(/],
   ],
 
   // mt-leak-analyzer.mjs — module basename + content regexes over the de-concat main-thread.js
-  BG_NAME: /(jsb|bridge|logger|report|monitor|track|request|fetch|http|storage|mmkv|getJSModule|NativeModules|GlobalEventEmitter|protobuf|crypto\b|md5|sdk)/i,
-  BG_CONTENT: /NativeModules|GlobalEventEmitter|getJSModule|\.bridge\b|core\.pipeCall|sendReport|reportError/,
+  BG_NAME:
+    /(jsb|bridge|logger|report|monitor|track|request|fetch|http|storage|mmkv|getJSModule|NativeModules|GlobalEventEmitter|protobuf|crypto\b|md5|sdk)/i,
+  BG_CONTENT:
+    /NativeModules|GlobalEventEmitter|getJSModule|\.bridge\b|core\.pipeCall|sendReport|reportError/,
 
   // mt-cutpoint-analyzer.mjs — background-only PACKAGES + app-module name signatures
   BG_PACKAGES: /^(@your-scope\/(request|btm-sdk|logger|tracker)|md5)\//,
-  BG_APP: /(^|\/)(request|requester|monitor|monitorV2|stableMonitor|apiParameterMonitor|reporter|postponeReporter|card-monitor|btm|tracker|telemetry|logger)\b/i,
+  BG_APP:
+    /(^|\/)(request|requester|monitor|monitorV2|stableMonitor|apiParameterMonitor|reporter|postponeReporter|card-monitor|btm|tracker|telemetry|logger)\b/i,
 
   // strip-mt-telemetry-loader.cjs — jsb-backed telemetry methods to strip on the main-thread layer.
   // ONLY list methods confirmed jsb-backed; never console-backed ones (those run on main-thread).

--- a/packages/skills/rspeedy-bundle-size/references/assets/signatures.cjs
+++ b/packages/skills/rspeedy-bundle-size/references/assets/signatures.cjs
@@ -1,3 +1,7 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
 /**
  * Background-only detection signatures, shared by all the bundle-size assets
  * (scan-levers.mjs, mt-leak-analyzer.mjs, mt-cutpoint-analyzer.mjs,

--- a/packages/skills/rspeedy-bundle-size/references/assets/signatures.cjs
+++ b/packages/skills/rspeedy-bundle-size/references/assets/signatures.cjs
@@ -1,0 +1,40 @@
+/**
+ * Background-only detection signatures, shared by all the bundle-size assets
+ * (scan-levers.mjs, mt-leak-analyzer.mjs, mt-cutpoint-analyzer.mjs,
+ * strip-mt-telemetry-loader.cjs). CommonJS so both the ESM tools (`import sig from
+ * './signatures.cjs'`) and the CJS loader (`require('./signatures.cjs')`) can read it.
+ *
+ * jsb-backed APIs (NativeModules / .bridge / getJSModule / GlobalEventEmitter) are
+ * GENUINELY background-only — the main/lepus thread has no jsb. Logger / monitor /
+ * telemetry terms are background-only ONLY when jsb-backed; a console-backed logger
+ * (`console.*`) runs on the main thread too, so those are "look here", not proof.
+ *
+ * CUSTOMIZE the logger/monitor/telemetry terms to YOUR stack — the defaults below are
+ * generic placeholders. (Inside ByteDance, the internal build overrides this whole file
+ * via the skill overlay with the real telemetry/SDK signatures.)
+ */
+module.exports = {
+  // scan-levers.mjs — [label, regex] matched against app SOURCE
+  LEAK_PATTERNS: [
+    // jsb-backed — always background-only
+    ['NativeModules', /\bNativeModules\b/],
+    ['getJSModule', /getJSModule\s*\(/],
+    ['jsb.bridge', /\.bridge\.|\bjsbCall\b|\brequestAdapter\b/],
+    ['nativeEvents', /\b(GlobalEventEmitter|subscribeEvent|addGlobalEventListener)\b/],
+    // monitor / telemetry — background-only ONLY when jsb-backed (customize these)
+    ['monitor', /\b(reportMonitor|hybridMonitor)\b/],
+    ['telemetry', /\.(reportEvent|reportError|logEvent|track)\s*\(/],
+  ],
+
+  // mt-leak-analyzer.mjs — module basename + content regexes over the de-concat main-thread.js
+  BG_NAME: /(jsb|bridge|logger|report|monitor|track|request|fetch|http|storage|mmkv|getJSModule|NativeModules|GlobalEventEmitter|protobuf|crypto\b|md5|sdk)/i,
+  BG_CONTENT: /NativeModules|GlobalEventEmitter|getJSModule|\.bridge\b|core\.pipeCall|sendReport|reportError/,
+
+  // mt-cutpoint-analyzer.mjs — background-only PACKAGES + app-module name signatures
+  BG_PACKAGES: /^(@your-scope\/(request|btm-sdk|logger|tracker)|md5)\//,
+  BG_APP: /(^|\/)(request|requester|monitor|monitorV2|stableMonitor|apiParameterMonitor|reporter|postponeReporter|card-monitor|btm|tracker|telemetry|logger)\b/i,
+
+  // strip-mt-telemetry-loader.cjs — jsb-backed telemetry methods to strip on the main-thread layer.
+  // ONLY list methods confirmed jsb-backed; never console-backed ones (those run on main-thread).
+  TELEMETRY_METHODS: ['reportEvent', 'reportError', 'logEvent', 'track'],
+};

--- a/packages/skills/rspeedy-bundle-size/references/assets/strip-mt-telemetry-loader.cjs
+++ b/packages/skills/rspeedy-bundle-size/references/assets/strip-mt-telemetry-loader.cjs
@@ -1,0 +1,59 @@
+/**
+ * Main-thread-layer ONLY loader: strips background-only telemetry calls from the
+ * main-thread bundle. Registered only on the `react:main-thread` layer, so the
+ * background layer keeps full telemetry.
+ *
+ * When it's safe — READ THIS BEFORE ADDING A METHOD: stripping a call on the
+ * main-thread layer is only behavior-neutral if that method is **jsb-backed**
+ * (the native logger isn't exposed to the main/lepus thread, so the call was
+ * already a no-op there). A **console-backed** logger (`console.*`) runs on the
+ * main thread too — stripping it LOSES real main-thread logs (a behavior change).
+ * So `METHODS` must list ONLY telemetry methods you've confirmed are jsb-backed.
+ * Verify each against your telemetry SDK's implementation before adding it.
+ *
+ * Mechanism: replacing `x.report(...)` with `void 0` neutralizes the call in any
+ * position (statement, `a && x.report()`, optional chain); the minifier DCEs the
+ * rest, and once a telemetry import has no remaining main-thread reference it shakes.
+ *
+ * Behavior-neutral: NO lifecycle removal (that would be a behavior change). Only
+ * the configured telemetry expression calls are removed.
+ */
+// jsb-backed telemetry method names live in signatures.cjs (overridable per stack /
+// via the internal overlay). ONLY confirmed jsb-backed methods belong there.
+const { TELEMETRY_METHODS } = require('./signatures.cjs');
+const METHODS = new Set(TELEMETRY_METHODS);
+const NEEDLE = new RegExp('\\.(' + [...METHODS].join('|') + ')\\(');
+
+module.exports = function stripMtTelemetryLoader(source) {
+  if (!NEEDLE.test(source)) return source; // fast path
+  try {
+    // Lazy-require INSIDE the try: SWC-only rspeedy projects often don't have
+    // @babel/core installed, and a missing module must not break the build.
+    // (If absent, the catch returns source unchanged — telemetry stays, build is fine.)
+    const babel = require('@babel/core');
+    const out = babel.transformSync(source, {
+      babelrc: false,
+      configFile: false,
+      compact: false,
+      sourceMaps: false,
+      parserOpts: { sourceType: 'unambiguous', allowReturnOutsideFunction: true },
+      plugins: [
+        function stripPlugin({ types: t }) {
+          const isTelemetry = (node) => {
+            const c = node && node.callee;
+            if (!c) return false;
+            const member = c.type === 'MemberExpression' || c.type === 'OptionalMemberExpression';
+            return member && c.property && c.property.type === 'Identifier' && METHODS.has(c.property.name);
+          };
+          const handle = (path) => {
+            if (isTelemetry(path.node)) path.replaceWith(t.unaryExpression('void', t.numericLiteral(0)));
+          };
+          return { visitor: { CallExpression: handle, OptionalCallExpression: handle } };
+        },
+      ],
+    });
+    return out && out.code ? out.code : source;
+  } catch {
+    return source; // never break the build
+  }
+};

--- a/packages/skills/rspeedy-bundle-size/references/assets/strip-mt-telemetry-loader.cjs
+++ b/packages/skills/rspeedy-bundle-size/references/assets/strip-mt-telemetry-loader.cjs
@@ -1,3 +1,7 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
 /**
  * Main-thread-layer ONLY loader: strips background-only telemetry calls from the
  * main-thread bundle. Registered only on the `react:main-thread` layer, so the
@@ -20,6 +24,7 @@
  */
 // jsb-backed telemetry method names live in signatures.cjs (overridable per stack /
 // via the internal overlay). ONLY confirmed jsb-backed methods belong there.
+// eslint-disable-next-line @typescript-eslint/no-require-imports -- CommonJS loader
 const { TELEMETRY_METHODS } = require('./signatures.cjs');
 const METHODS = new Set(TELEMETRY_METHODS);
 const NEEDLE = new RegExp(`\\.(${[...METHODS].join('|')})\\(`);
@@ -30,6 +35,7 @@ module.exports = function stripMtTelemetryLoader(source) {
     // Lazy-require INSIDE the try: SWC-only rspeedy projects often don't have
     // @babel/core installed, and a missing module must not break the build.
     // (If absent, the catch returns source unchanged — telemetry stays, build is fine.)
+    // eslint-disable-next-line @typescript-eslint/no-require-imports -- lazy optional dep
     const babel = require('@babel/core');
     const out = babel.transformSync(source, {
       babelrc: false,

--- a/packages/skills/rspeedy-bundle-size/references/assets/strip-mt-telemetry-loader.cjs
+++ b/packages/skills/rspeedy-bundle-size/references/assets/strip-mt-telemetry-loader.cjs
@@ -22,7 +22,7 @@
 // via the internal overlay). ONLY confirmed jsb-backed methods belong there.
 const { TELEMETRY_METHODS } = require('./signatures.cjs');
 const METHODS = new Set(TELEMETRY_METHODS);
-const NEEDLE = new RegExp('\\.(' + [...METHODS].join('|') + ')\\(');
+const NEEDLE = new RegExp(`\\.(${[...METHODS].join('|')})\\(`);
 
 module.exports = function stripMtTelemetryLoader(source) {
   if (!NEEDLE.test(source)) return source; // fast path
@@ -36,23 +36,36 @@ module.exports = function stripMtTelemetryLoader(source) {
       configFile: false,
       compact: false,
       sourceMaps: false,
-      parserOpts: { sourceType: 'unambiguous', allowReturnOutsideFunction: true },
+      parserOpts: {
+        sourceType: 'unambiguous',
+        allowReturnOutsideFunction: true,
+      },
       plugins: [
         function stripPlugin({ types: t }) {
           const isTelemetry = (node) => {
-            const c = node && node.callee;
+            const c = node?.callee;
             if (!c) return false;
-            const member = c.type === 'MemberExpression' || c.type === 'OptionalMemberExpression';
-            return member && c.property && c.property.type === 'Identifier' && METHODS.has(c.property.name);
+            const member =
+              c.type === 'MemberExpression' ||
+              c.type === 'OptionalMemberExpression';
+            return (
+              member &&
+              c.property &&
+              c.property.type === 'Identifier' &&
+              METHODS.has(c.property.name)
+            );
           };
           const handle = (path) => {
-            if (isTelemetry(path.node)) path.replaceWith(t.unaryExpression('void', t.numericLiteral(0)));
+            if (isTelemetry(path.node))
+              path.replaceWith(t.unaryExpression('void', t.numericLiteral(0)));
           };
-          return { visitor: { CallExpression: handle, OptionalCallExpression: handle } };
+          return {
+            visitor: { CallExpression: handle, OptionalCallExpression: handle },
+          };
         },
       ],
     });
-    return out && out.code ? out.code : source;
+    return out?.code ? out.code : source;
   } catch {
     return source; // never break the build
   }

--- a/packages/skills/rspeedy-bundle-size/references/cross-project-triage.md
+++ b/packages/skills/rspeedy-bundle-size/references/cross-project-triage.md
@@ -1,0 +1,66 @@
+# Triage at scale — picking which projects/levers to measure first across many repos
+
+The core workflow is **measure-first per project** (build → rsdoctor/stats → three-layer split). But when you're handed *many* projects (a fleet dashboard, a monorepo of 50+ apps, "optimize our Lynx bundles"), you cannot build all of them to decide where to look — a full build is minutes each and many fail. You need a **cheap source-level triage** that ranks where a real measure will pay off, *then* you measure-first the winners.
+
+This is a triage, not a verdict. A source hit means "worth a real build+measure here," **not** "confirmed bloat." Never report a triage signal as a finding — it's a prioritizer for the expensive, accurate step.
+
+## The scanner: `scan-levers.mjs`
+
+A reusable static scanner lives at [assets/scan-levers.mjs](assets/scan-levers.mjs). It walks every project's *source* (node_modules excluded) and emits, per project + aggregated:
+
+- **mt-leak** — background-only API surfaces referenced in app source: the jsb-backed ones (always background-only) `NativeModules`, `getJSModule(`, jsb bridge (`.bridge.`/`jsbCall`/`requestAdapter`), native event emitters (`GlobalEventEmitter`/`subscribeEvent`); plus monitor/telemetry calls (background-only **only when jsb-backed** — customize these to your stack). A real leak must *also* appear in `main-thread.js` — source presence is the gate, not proof.
+- **guard ratio** — of the files with leak signal, how many already use `__BACKGROUND__`/`__MAIN_THREAD__`/`'background only'`. **Low guard ratio = high opportunity** (unguarded background-only code is the leak candidate).
+- **media** — inline base64 data-URIs (>5 kB) and large committed images (>50 kB).
+- **sideEffects** — whether `package.json` declares `sideEffects` (tree-shaking enabler).
+- **dupPkg** — (installed repos only) same dep resolved at multiple versions in `node_modules/.pnpm`.
+
+Run it from the analysis repo: `node scripts/scan-levers.mjs` → writes `lever-scan.json` + prints the aggregate. It points you at the 5–10 projects worth a real build, instead of building 90.
+
+## How to read the output (and its traps)
+
+Ranking signal, in priority order:
+
+1. **Unguarded main-thread leak** — projects with many `leakFiles` and a **low `guardRatio`** (≪0.5). These are the best Lever 3 candidates: background-only APIs all over the source with no thread guards. Cross-reference the project's *baseline main-thread.js size* — a big main-thread bundle + unguarded leaks = measure here first.
+2. **Missing `sideEffects`** — near-universal in practice (see below); cheap to flag but the actual win still needs a build (the minifier may already handle it).
+3. **Media** — large committed images / inline base64. But **media plugins are usually CI-only** (see gotchas §6) — a project flagged for "big images" may already compress them in CI. Confirm against a CI-equivalent build before promising a number.
+4. **Duplicate deps** — see the trap below; treat the raw count as noise.
+
+### ⚠️ Trap 1: the duplicate-dep count is dominated by the dev toolchain
+
+The `.pnpm` scan counts **every** package at multiple versions — including `esbuild`, `commander`, `typescript`, `@babel/core`, `postcss`, `type-fest`, `fs-extra`. These are **build-time deps that never ship in the bundle**, so a repo showing "1305 duplicate packages" is almost entirely irrelevant to size. The skill's dedup lever (three-levers §Lever 2) is about **runtime** libs shipped into `.lynx.bundle`: UI component libraries, lodash, the ReactLynx runtime, business SDKs. Filter the dup list to runtime/UI/util packages before treating any of it as a lever — and even then, confirm the package is actually in the *shipped* bundle (rsdoctor duplicates), because a duplicated dev/SSR-only dep is free.
+
+### ⚠️ Trap 2: source presence ≠ main-thread presence
+
+A file that references `NativeModules` may be a background-only module that ReactLynx already shakes out of `main-thread.js`. The scan cannot know — it reads source, not the post-shake bundle. So a high `leakFiles` count tells you *this project does a lot of native/jsb/telemetry work*, which **correlates** with main-thread leakage, but the byte win only exists if those APIs survive into `main-thread.js`. Always confirm with a readable `main-thread.js` build (three-levers §Lever 3 ⭐) before editing.
+
+### ⚠️ Trap 3: a telemetry signature over-counts a property name
+
+A telemetry-client signature can match a *property name* too (e.g. a `webXxxLogger` member), which is often a *guarded* logger client (`if(__BACKGROUND__) webXxxLogger...`). A high count ≠ leak. It's a "look here," nothing more.
+
+## Empirical baseline — what a real fleet looks like
+
+Scanning a real fleet (~370 ReactLynx projects across ~80 monorepos) gave the prevalence below. Use it to calibrate expectations — these are *signals*, deflated by the traps above:
+
+| Signal | Prevalence | Read |
+|---|---|---|
+| Source has any background-only leak signal | **~74%** (274/372) | leak work is broadly *relevant*, rarely *clean* |
+| …and mostly **unguarded** (guardRatio<0.5) | **~62%** (230/372) | most projects don't thread-guard telemetry/jsb — the systemic opportunity |
+| Missing `sideEffects` in package.json | **~99%** (367/372) | near-universal; but minifier often covers it — needs a build to value |
+| Has large committed images | **~33%** (124/372) | media lever candidates — but verify CI compression first |
+| Has >5 kB inline base64 | **~3%** (12/372) | rare; when present, easy externalize win |
+| Repos with any duplicate runtime+dev deps | 32 repos | **dominated by dev toolchain — mostly noise** (Trap 1) |
+
+Most-referenced background-only API across the fleet (file counts): **telemetry client 220 · native events 147 · NativeModules 130 · getJSModule 127 · jsb bridge 101 · monitor 89 · other telemetry 74**. The headline: **telemetry + jsb/native glue is referenced in app source almost everywhere, almost always unguarded.** That makes the *jsb-backed telemetry strip* (next section) a broadly-applicable Lever-3 move across a fleet — and the reason it's worth a reusable asset rather than a per-project hand-edit.
+
+## Reusable lever: main-thread jsb-backed telemetry strip
+
+Because a **jsb-backed** telemetry/logger client isn't exposed to the main/lepus thread, stripping those *calls* from the main-thread layer is behavior-neutral. **⚠️ This holds ONLY for jsb-backed methods** — a console-backed logger (`console.*`) runs on the main thread too, so stripping it would lose real main-thread logs (a behavior change). Confirm each method's underlying impl (jsb vs console), then list only the jsb-backed ones in the loader's `METHODS`. Two drop-in files:
+
+- [assets/strip-mt-telemetry-loader.cjs](assets/strip-mt-telemetry-loader.cjs) — a babel loader that replaces a **configurable** set of telemetry methods (e.g. `x.reportEvent(...)` / `.track(...)` — any position: statement, `a && x.report()`, optional chain) with `void 0`. The `METHODS` set is yours to fill with confirmed jsb-backed names. Fast-path skips files with no match. Never throws (returns source on parse error).
+- [assets/plugin-strip-mt-telemetry.ts](assets/plugin-strip-mt-telemetry.ts) — an rsbuild plugin that registers the loader **only on the `react:main-thread` layer** (so background telemetry is untouched), running after swc.
+
+Wire it by adding `pluginStripMtTelemetry()` to the rspeedy `plugins` array. The background layer keeps full telemetry; the main-thread layer loses the dead calls, and any telemetry import whose *last* main-thread reference was a stripped call then shakes out (the "remove every reference" rule from three-levers §Lever 3).
+
+**Scope discipline (why this asset is telemetry-only):** a more aggressive variant of this loader *also* removed `componentDidMount/WillUnmount/DidUpdate` from main-thread — a bigger win but a **behavior change** (needs real-device verification). The reusable asset here is deliberately telemetry-only so it stays a safe default for an unfamiliar project. If you want the lifecycle strip too, do it as a separate, explicitly-flagged change with device verification — don't fold it into the "safe" pass.
+
+**Still measure.** Even a behavior-safe lever can move ~0 bytes if telemetry wasn't actually leaking into main-thread on that project, or if other unguarded references keep the import alive. Build `.lynx.bundle` before/after and report the real delta.

--- a/packages/skills/rspeedy-bundle-size/references/dual-thread-architecture.md
+++ b/packages/skills/rspeedy-bundle-size/references/dual-thread-architecture.md
@@ -1,0 +1,76 @@
+# Dual-thread architecture & build output — the model behind the size levers
+
+Before optimizing a Lynx bundle you must understand *why* there are two JS layers and *what* the build actually emits. Every main-thread size finding rests on this model. For the authoritative runtime model see the ReactLynx docs (https://lynxjs.org/react) and the `lynx-stack` source (https://github.com/lynx-family/lynx-stack).
+
+## Why two layers exist (main-thread vs background)
+
+ReactLynx is **React split across two threads**, by design:
+
+| | Main thread | Background thread |
+|---|---|---|
+| Mental model | "lightweight UI driver" | "logic & state center" |
+| Job | first-screen direct render + apply Patches + touch-following MTS | full render + generate Patches + lifecycle |
+| Renders | `SnapshotInstance` tree → Element PAPI → `FiberElement` tree (UI) | full Preact renders `BackgroundSnapshotInstance` |
+| Patches | **receives & applies** (`insertBefore`/`setAttribute`/`removeChild`) | **Hydrates, diffs, and generates** Patches |
+| Lifecycle | **none** (`effect`, mount/update happen on background) | owns `useEffect`/`componentDidMount`/`componentDidUpdate` |
+| State | — | `setState → rerender → Patch` |
+| Touch | direct style updates for `bindtap` etc. (MTS) | — |
+
+The point of the split: the main thread does the **minimum** needed to paint the first screen fast and respond to touch without a round-trip, while all the heavy logic/lifecycle/state lives on the background thread. In rsdoctor these are the `react:main-thread` and `react:background` **layers**.
+
+**Size consequence (the whole reason this matters for bundle work):** the main-thread layer should stay *lean*. Anything that only the background thread needs (network, jsb, loggers, lifecycle, business logic) is dead weight if it leaks into `main-thread.js` — it bloats both the bundle and the first-screen cost. That is exactly the "main-thread leakage" lever in [three-levers.md](three-levers.md).
+
+## What the build emits: main-thread.js, background.js, .lynx.bundle
+
+Rspeedy uses **Rspack's Layers** capability to build, per Entry, **two** JS artifacts:
+
+```
+Entry ──Rspack Layers──> main-thread.js   (react:main-thread layer)
+                         background.js     (react:background layer; also generates the CSS)
+                                │
+            main-thread.js + background.js + cssMap
+                                │
+                          ┌─────▼─────┐
+                          │ tasm encode│   (compile to binary)
+                          └─────┬─────┘
+                                ▼
+                          .lynx.bundle      ← the binary the Lynx engine actually consumes
+```
+
+So:
+
+- **`main-thread.js`** — the render-path code (the `react:main-thread` layer). Should be small.
+- **`background.js`** — the app-logic code (the `react:background` layer). Also responsible for generating the **CSS**.
+- **`cssMap`** — the CSS produced from `background.js`.
+- **`.lynx.bundle`** — **the final shipped product**: a *binary* produced by `tasm encode` over `main-thread.js` + `background.js` + `cssMap`. This is what the Lynx engine loads. You don't read it directly. In an open-source rspeedy build the emitted file is named **`<name>.lynx.bundle`** (the Lynx artifact); a build that also targets web emits a sibling **`<name>.web.bundle`**. This skill's size metric is always the **`.lynx.bundle`** — `find output -name '*.lynx.bundle'` after a build; don't assume the path.
+
+### Why you build with DEBUG to see the JS
+
+`.lynx.bundle` is binary, so to inspect the human-readable intermediates you enable debug output:
+
+```bash
+DEBUG='rspeedy,rsbuild' pnpm build
+# then read dist/.rspeedy/main/main-thread.js  and  dist/.rspeedy/main/background.<hash>.js
+```
+
+This is also why size analysis works off a module-level `layer` field (which thread a module lands in) — available in both rsdoctor's `moduleGraph` and rspack's `stats.toJson({ modules: true })` — rather than off the final binary. See [measure-with-rsdoctor.md](measure-with-rsdoctor.md).
+
+## Code elimination (代码裁剪) — the built-in DCE, and how to steer it
+
+ReactLynx **automatically tree-shakes thread-inappropriate code**. By default, `useEffect`, `componentDidMount`, and `bindtap` callbacks are **shaken out of `main-thread.js`** — they only belong on the background thread. This automatic DCE is why a healthy main-thread layer is naturally small.
+
+But the compiler can't always statically decide which thread a piece of code belongs to. When it can't, **the developer must mark it**. The official levers:
+
+| Lever | Form | Meaning |
+|---|---|---|
+| Compile-time macro | `__BACKGROUND__` (`__JS__` = deprecated alias) | code only for the background thread |
+| Compile-time macro | `__MAIN_THREAD__` (`__LEPUS__` = deprecated alias) | code only for the main thread |
+| Function directive | `'background only'` | keep this function body **only** on the background thread |
+
+These are the actual mechanism behind the "main-thread leakage" fix: when SDK/app code that should be background-only leaks into `main-thread.js`, the cure is a `'background only'` directive (or a `__BACKGROUND__` guard) **at the definition site**. If that site is inside a library you don't own, you can't fix it from app code — report it as a library ask. See [three-levers.md](three-levers.md) §Lever 3. For the directive's exact semantics and accepted forms, defer to the `reactlynx-best-practices` skill (`detect-background-only` rule).
+
+## How a module ends up on a layer (no filename magic)
+
+The ReactLynx plugin's entry setup (in [lynx-stack](https://github.com/lynx-family/lynx-stack); grep for where entries are added with a `layer`) adds **each user entry twice** — once with `layer: MAIN_THREAD`, once with `layer: BACKGROUND`, both pointing at the same source. Rspack then builds **two module graphs from the same entry**. A module lands in the main-thread layer simply because the main-thread graph reaches it (after the DCE above prunes what shouldn't be there), and likewise for background. The same source file can appear in *both* layers (compiled twice with different transforms) or be shaken out of one.
+
+So there is **no filename-based rule** — reachability + the DCE/directives decide everything. For auditing, just read `module.layer`; don't reason about file extensions.

--- a/packages/skills/rspeedy-bundle-size/references/measure-with-rsdoctor.md
+++ b/packages/skills/rspeedy-bundle-size/references/measure-with-rsdoctor.md
@@ -1,0 +1,147 @@
+# Measuring a rspeedy bundle with rsdoctor
+
+The official, supported way to get a per-module breakdown of a rspeedy build. See the rspeedy guides on using rsdoctor and bundle analysis (https://lynxjs.org / https://github.com/lynx-family/lynx-stack).
+
+## Enable rsdoctor via config (do NOT install a plugin manually)
+
+rspeedy ships rsdoctor support behind `tools.rsdoctor`. You do **not** `pnpm add @rsdoctor/rspack-plugin`, and you do **not** wire any rsdoctor fork by hand. Just add config:
+
+```ts
+// lynx.config.ts
+export default defineConfig({
+  // ...
+  tools: {
+    rsdoctor: {
+      disableClientServer: true,        // headless, don't open the browser UI
+      brief: { writeDataJson: true },   // emit machine-readable data
+    },
+  },
+})
+```
+
+Then build with the env flag:
+
+```bash
+RSDOCTOR=true rspeedy build
+# or via the project's package script:
+RSDOCTOR=true pnpm build
+```
+
+### Allowed config fields (the schema is strict)
+
+rspeedy validates `tools.rsdoctor` and **rejects unknown keys** with errors like
+`Unknown property '$input.tools.rsdoctor.disableTOSUpload'`. Known-good fields:
+
+- `disableClientServer: boolean` — headless mode, no UI server
+- `brief.reportHtmlName: string`
+- `brief.writeDataJson: boolean`
+
+Fields that are **rejected** (don't use them, they're from a different rsdoctor API surface): `disableTOSUpload`, `output`, `mode`.
+
+If you hit a validation error, read the generated validator function in the rspeedy package to see the exact allowed shape rather than guessing.
+
+## The output: single JSON vs sharded `.rsdoctor/`
+
+There are two possible output shapes depending on version/config:
+
+### A. Single `rsdoctor-data.json`
+Shape: `{ data: SDK.BuilderStoreData, clientRoutes }`. The `data` object holds the domains you care about.
+
+### B. Sharded `.rsdoctor/` directory
+A `manifest.json` plus per-domain shard files. Each shard is **base64 of zlib-compressed** data. Critically:
+
+> A multi-shard domain is **ONE zlib stream split across files**, not N independent streams.
+
+So to reconstruct a multi-shard domain you must **concatenate the base64 TEXT of the shards in order, THEN base64-decode and inflate once**. Inflating each shard independently fails with `unexpected end of file`. (Verified on the `chunkGraph` domain.)
+
+```js
+// pseudo-code for reconstructing one sharded domain
+const b64 = shardPaths.map(p => fs.readFileSync(p, 'utf8')).join('')   // concat TEXT first
+const buf = zlib.inflateSync(Buffer.from(b64, 'base64'))               // then decode + inflate ONCE
+const domain = JSON.parse(buf.toString('utf8'))
+```
+
+Note: a single `rsdoctor-data.json` is **not** always auto-produced; if you only see `.rsdoctor/`, use approach B.
+
+## What's in the data (the domains)
+
+`SDK.BuilderStoreData` domains: `moduleGraph`, `chunkGraph`, `packageGraph`, `summary`, `errors`, `loader`, etc.
+
+The one that matters most for size work is **`moduleGraph.modules`**. Each module:
+
+| Field | Meaning |
+|---|---|
+| `path` | source path |
+| `layer` | **`react:main-thread` or `react:background`** (stats.json exposes this too — see below) |
+| `size.sourceSize` | raw source bytes |
+| `size.parsedSize` | bytes in the bundle (post-transform) |
+| `size.gzipSize` | gzipped bytes (what actually ships over the wire) |
+| `dependencies` / `imported` | edges for tracing why a module is included |
+| `chunks` | which chunks it lands in |
+| `kind` | import kind |
+
+**Use `gzipSize` for "what does this cost the user", `parsedSize` for "how much code is this".**
+
+## Getting stats.json (the official way)
+
+rspeedy emits `stats.json` for you — no custom plugin needed. The built-in `lynx:stats-json` plugin writes `<distPath>/stats.json` (e.g. `output/stats.json`) in `onAfterBuild`, gated on `config.performance.profile`. Two ways to turn it on:
+
+> **Heads-up: a resource-merge / move plugin may relocate it.** Some projects add a plugin that moves output around, so `stats.json` and the shipped `.lynx.bundle` can end up under a nested dir rather than the top of `output/`. Don't assume the path — `find output -name stats.json` / `find output -name '*.lynx.bundle'` after the build.
+
+```ts
+// 1. config — lynx.config.ts
+export default defineConfig({
+  performance: { profile: true },
+})
+```
+
+```bash
+# 2. env var — DEBUG containing rspeedy, rsbuild, or *
+DEBUG=rspeedy pnpm build      # defaults.ts sets performance.profile = true when isDebug()
+```
+
+(Source: `@lynx-js/rspeedy` in [lynx-stack](https://github.com/lynx-family/lynx-stack) — grep for the stats-json plugin, the config defaults, and the `isDebug` util.) The plugin calls `stats.toJson({})` — the **default preset**, which already includes `modules` with `layer`.
+
+## rsdoctor vs stats.json
+
+| | rsdoctor data | stats.json |
+|---|---|---|
+| How to get | `tools.rsdoctor` + `RSDOCTOR=true` | `performance.profile: true` **or** `DEBUG=rspeedy` → `output/stats.json` |
+| Has `layer` (thread) | **yes** | **yes** — rspack `KnownStatsModule.layer`, values `react:main-thread` / `react:background` |
+| Per-module `gzipSize` / `parsedSize` | **yes** (built in) | no — `size` only; no gzip |
+| Duplicate-package / tree-shaking analysis | **yes** (domains + agent-cli) | you compute it yourself |
+| Size of the file | manageable | default preset is moderate (~16 MB on the tiny demo); `all: true` is the ~1GB monster |
+
+They are **independent** — stats.json is not "contained in" rsdoctor data; rsdoctor reconstructs its own graphs.
+
+**Verified empirically** (a minimal rspeedy app, Rspeedy 0.14.5 / Rspack 1.7.11): the official `DEBUG=rspeedy` `output/stats.json` carries `layer` on nearly every module with exactly `react:main-thread` / `react:background`. So **stats.json separates the two threads out of the box** — the reason to prefer rsdoctor is not the layer field but that rsdoctor gives gzip sizes and duplicate/tree-shaking analysis for free, whereas stats.json gives you raw `size` and you do the rest.
+
+Precision note: `layer` sits on the **concatenated module group** (e.g. `./src/index.tsx + 90 modules`) and its top-level members; nested child modules inherit it and don't repeat the key, and a few runtime/global modules carry no `layer` at all. Group by the top-level module's `layer` when sizing by thread.
+
+### If stats.json is too big to read
+
+The official `performance.profile` output uses the **default preset** and is moderate (~16 MB on the tiny demo; bigger on a real app, but not pathological). The ~1GB blowup only happens if you deliberately customize stats to **`all: true`** (it inlines every module's `source` plus the full graph). If you've done that and the file exceeds V8's ~512MB string limit, `readFileSync` as a string throws `ERR_STRING_TOO_LONG` — stream it line-by-line (`readline`), or just don't use `all: true` (the default preset already has `modules` + `layer` + `size`, which is all you need for layer-based sizing).
+
+## The `@rsdoctor/agent-cli` querying tool
+
+`rsdoctor-agent` = the `@rsdoctor/agent-cli` package (repo `web-infra-dev/rsdoctor`, `packages/agent-cli`). It's a cac-based CLI that reads a JSON file and answers queries. Useful commands:
+
+```bash
+rsdoctor-agent tree-shaking retained-modules --category barrel,cjs,side-effects --sort gzipSize
+rsdoctor-agent packages duplicates
+rsdoctor-agent build summary
+```
+
+Caveat: it reads a plain JSON via `readFileSync` and does **not** resolve the sharded-manifest external references — feed it a reconstructed single JSON, not a `.rsdoctor/` manifest.
+
+## Environment gotcha
+
+Builds require the project's pinned Node (via fnm/nvm, e.g. `fnm exec --using=20.19.0 -- pnpm build` or `nvm exec 20.19.0 pnpm build`). Newer Node (24+) breaks rspeedy config loading via `strip-types` inside `node_modules`. macOS has no `timeout` command, and a `.DS_Store` race can make `rm -rf output` report "Directory not empty" — re-run or remove `.DS_Store` first.
+
+**A normal production build may upload sourcemaps and stats to monitoring/perf services.** A real app's build printed an `Upload sourcemap url is https://...` line during the build. For repeated analysis builds, find the project's **offline / upload-disabled** mode (an env flag, a `--no-upload`-style script, or a local build target) so you're not pushing artifacts on every run — it's slower and has side effects you don't want from an analysis loop.
+
+**Tip: the sourcemap-upload / monitoring plugin can simply be commented out for analysis builds.** It noticeably slows the build (sourcemap generation + upload) but has **negligible bundle-size impact** — it only injects a small runtime banner. So when you're iterating on before/after size measurements, comment out the monitoring/upload plugin in `lynx.config.ts` (and similar plugins) to speed up the loop; the `.lynx.bundle` size delta you measure stays valid. Restore it afterward.
+
+## Importer tracing needs a non-concatenated build
+
+If you'll do **reverse-import / dominator analysis** on the main-thread graph (see [three-levers.md](three-levers.md) §Lever 3), build with `tools.rspack.optimization.concatenateModules: false` first. Production scope-hoisting collapses each module's `reasons` to the concatenated-group root, so the importer edges are wrong and the analysis produces false positives. Revert the config after. (rsdoctor's graph is captured pre-hoist and doesn't need this.)

--- a/packages/skills/rspeedy-bundle-size/references/rspeedy-gotchas.md
+++ b/packages/skills/rspeedy-bundle-size/references/rspeedy-gotchas.md
@@ -1,0 +1,83 @@
+# Rspeedy/Lynx gotchas that bite bundle-size work
+
+Things that will produce wrong findings or broken builds if you treat a Lynx app like a generic webpack project. Read before editing config or asserting a finding. The behaviors below live in **lynx-stack** (https://github.com/lynx-family/lynx-stack) — when in doubt, grep the source and confirm rather than guessing.
+
+## 1. The two threads ship at different, fixed ES targets — don't "fix" them for size
+
+rspeedy compiles the two layers to **different ES baselines**, and this is a deliberate platform decision people normally don't touch:
+
+- **Main thread (`react:main-thread`): fixed ES2019.** The ReactLynx plugin's per-layer swc loader pins the main-thread `env` to a fixed ES2019 baseline regardless of dev/prod — the source comment: "the main thread targets an es2019 engine, so its baseline is a platform constant."
+- **Background thread (`react:background`): ES2015 in production** (ES2019 in dev). From the `getESVersionTarget(isProd)` util (`isProd ? 'es2015' : 'es2019'`), applied via rspeedy's swc plugin.
+- **Both threads lower `let`/`const` → `var`** (`transform-block-scoping`), on purpose — "QuickJS parses `var` faster." So seeing `var` everywhere is not a missed optimization.
+
+**Why it matters for size work:** these targets are fixed and engine-driven; **don't propose retargeting to a newer ES version to save bytes.** The output is already es2015/es2019 (arrow functions, shorthand, etc. are *kept*), so the realistic byte savings are tiny, and you'd be fighting a platform constant. The one syntax that *is* down-leveled (`let`/`const`→`var`) is a parse-time choice, not a bug.
+
+**Some projects go lower on purpose (do NOT generalize):** a project may additionally pin `tools.rspack.output.environment` to **full ES5** (`arrowFunction:false, templateLiteral:false, destructuring:false, optionalChaining:false, ...`), going *below* the es2015/es2019 defaults — typically to match an older bundler's output shape or shave engine parse time. Full-ES5 output is slightly *larger* in bytes (modern syntax is more compact), so it's a size-vs-parse-time tradeoff. If you encounter such a config, treat it as a deliberate exception, not the norm — the norm is main=es2019 / background=es2015 above.
+
+## 2. rsdoctor data can be sharded — reconstruct it correctly
+
+If the build emits a `.rsdoctor/` directory (manifest + shards) instead of a single `rsdoctor-data.json`, a multi-shard domain is **one zlib stream split across files**. Concatenate the base64 TEXT of the shards in order, then base64-decode and inflate **once**. Inflating shards independently fails. Details in [measure-with-rsdoctor.md](measure-with-rsdoctor.md). Get this wrong and every size number you report is garbage.
+
+## 3. Use the pinned Node version
+
+Builds require the project's pinned Node (commonly `20.19.0`):
+
+```bash
+# via your Node version manager — fnm:
+fnm exec --using=20.19.0 -- pnpm build
+# or nvm:
+nvm exec 20.19.0 pnpm build
+```
+
+Node 24+ breaks rspeedy config loading (strip-types runs inside `node_modules` and chokes). If a build fails with a config-parse error on a machine with a newer default Node, this is almost always the cause.
+
+## 4. macOS shell traps during builds
+
+- **No `timeout` command** on stock macOS — commands using it fail with `timeout: command not found`. Run without it, or install coreutils (`gtimeout`).
+- **`.DS_Store` race**: `npm run clean` / `rm -rf output` can report `Directory not empty` because Finder/Spotlight just wrote `.DS_Store`. Re-run, or `rm -rf output` manually (which removes the `.DS_Store` too), then build.
+
+## 5. Don't manually wire rsdoctor
+
+rspeedy owns the rsdoctor integration via `tools.rsdoctor` + `RSDOCTOR=true`. Do **not** `pnpm add @rsdoctor/rspack-plugin` and push a plugin into `tools.rspack.plugins`, and don't reverse-engineer any internal rsdoctor fork. The config path is the supported one and respects the project's schema (which rejects unknown keys). See [measure-with-rsdoctor.md](measure-with-rsdoctor.md).
+
+## 6. Image-optimization plugins are often CI-only — a local build ships uncompressed media
+
+Projects frequently gate image plugins on a CI flag, e.g. `pluginCompressImage({ open: IS_CI })` and `pluginRankImg({ open: IS_CI })` where `IS_CI` is derived from a CI env var. So a **plain local `npm run build` does NOT compress/downscale images** — the emitted assets are the raw originals (e.g. multi-MB PNGs). **Don't judge shipped media size from a local build**: you'll wildly overstate it and "discover" a WebP/compression lever that CI already applies. To assess real media size + remaining headroom, build CI-equivalent (set the project's CI flag) or inspect a CI artifact. (JS minify is usually gated on prod-mode, not CI, so `.lynx.bundle`/JS measurements from a local prod build are still valid — but media isn't.)
+
+## 7. The first cold build is ~2.4% bigger than warm — warm the cache before measuring before/after
+
+Measured on a real project: the **first build after a cold rspack/build cache** produced `.lynx.bundle` = 5611.3 kB, while **every subsequent warm build** produced 5479.8 kB (≈ the published baseline) — a stable **~2.4% cold-cache premium**. The byte difference is real and reproducible, not noise.
+
+**Why it ruins before/after work:** the natural script is `build baseline → patch → build optimized → measure`. The baseline build runs cold, the optimized build runs warm — so the optimized chunk looks ~2.4% smaller **purely from cache warmup**, and you credit the lever for a win it didn't produce. (This silently inflated an earlier `extractStr` fleet measurement.)
+
+**Discipline:** before measuring a lever, **warm the cache** — build once and discard, *then* measure baseline (warm) and optimized (warm). Or build each variant twice and take the second. A `.lynx.bundle` delta under ~3% is inside the cold-cache band and must be re-measured warm before you believe it. (The published baseline in a dashboard is a *warm* number; a single fresh clone+build won't reproduce it on the first try.)
+
+## 8. An anomalously huge page is often a whole directory swept in by `webpackContext`/glob — quantify it, but don't assume it's a bug
+
+Found on a real app whose page was **71 MB**: an i18n `import.meta.webpackContext('../locales', …)` had pulled **all 57 languages' full help-article content** into the chunk (verified by grepping a distinctive Burmese/Thai string — present). main-thread.js 36 MB + background.js 37 MB ≈ 71 MB. Replacing the context with an explicit single import (`import en from '../locales/en.json'`) measured **71 MB → 1.5 MB (−97.8%)**.
+
+**But treat this as a *quantified tradeoff*, not a defect — the all-languages bundle may be deliberate.** On that app the **prod** regExp was `/\.json$/` (matches *all*) while **dev** was the *restricted* one — i.e. prod intentionally bundles more, and the source comment said the localizations are static so they're "available at the initial screen" (instant any-language first screen, no async fetch). That's a real product choice (offline/any-language/language-switch without a round-trip) whose price just happens to be large. **Your job is to make the price visible — "keeping all 57 languages costs ~70 MB/user; per-language loading would be ~1.5 MB" — and let the team decide.** Don't call it a bug or ship the en-only hardcode (it breaks non-active-language first screen): the production-correct version keeps the **active** language synchronous (it's first-screen content) and loads the rest at runtime (server/host), which is the i18n lever's first-screen caveat (three-levers §i18n) at extreme scale.
+
+Lesson: when a page is anomalously huge, grep the built chunk for whole directories of content (locales, all-icon sets, data JSON) a `webpackContext`/glob may have swept in — it's often the biggest number on the table. Quantify the per-item-needed alternative, present it as an option with its first-screen/UX cost, and let the owner weigh it.
+
+## 9. Measure before asserting; report the wall honestly
+
+The recurring lesson from real audits: an already-optimized project has **no cheap JS wins left**. Tree-shaking is done, `sideEffects` is correct, DCE nets ~0 at the bundle level, and the main-thread leak lives in SDK libraries you can't edit from app code. When that's the state, **say it** — the value is an accurate map (media is the lever; main-thread leak needs a library change), not a pile of marginal diffs that look like progress.
+
+## 10. The init-time singleton is a structural floor — gating call-sites can't shake it
+
+When a module **constructs an object/class at load time** (`const bridge = new BridgeCore()`, a registered singleton, an engine instance), that instance — and every method body it carries — is referenced by the module's top-level code, so it survives DCE **no matter how you guard the call-sites**. Tree-shaking removes *unreferenced* declarations; an eagerly-constructed singleton is referenced by construction.
+
+Concretely (measured on one real jsb bridge SDK): selectively prepending `if(__MAIN_THREAD__)return;` to the top-level **jsb wrapper functions** (those delegating to the bridge singleton) shook their bodies out of main-thread (−30.1 KB), but the residual `this.bridge.call/on/off` + `NativeModules` lived in an **ES6 class instantiated at module-init**. Those are class methods reached through the singleton, not top-level functions — so call-site gating left them untouched. This is the same shape as a first-screen render engine that's `new`'d at init (a Pixi-like draw engine): code referenced at load time is a floor.
+
+**Implication for the main-thread leak lever:** the shakeable part of a jsb/SDK leak is the **leaf wrappers**; the **core** (the constructed singleton) only shakes if you gate the *instantiation itself* — wrap the `new`/registration in `if (__BACKGROUND__)`, or split the constructed object into a background-only module. On a single app that means a deep library patch (fragile, version-specific, app-wide blast radius for a core jsb lib). The clean fix is **upstream in the library** — ship the `.lynx.js` build with the bridge core `__BACKGROUND__`-gated at construction. Quantify the leaf win first: if it's ~0.4% and the rest is this floor, recommend the upstream gate rather than a local patch.
+
+## 11. de-concat also disables `__split__` code-splitting — it inflates already-split components back into main-thread
+
+Beyond JSON tree-shaking and scope-hoist DCE (§10, three-levers anchor 2), a `concatenateModules:false` (de-concat) build also **defeats a build-level component-split directive** (some toolchains provide a `<Comp __split__="X" />` directive that splits heavy/interaction-only components — popups, modals, secondary cards — off the first-screen main thread). On de-concat those split components get **inlined back into `main-thread.js`**, so a per-module/per-package aggregation of a de-concat build will show, e.g., discount/coupon popups as a huge first-screen chunk that *looks* like a juicy lazy-load lever — when in the real build they're already `__split__`'d to the background thread (`grep -c DiscountPopup main-thread.js` = 0).
+
+**Before recommending "lazy-load these popups," check the REAL build**: `grep` the component name in the production `main-thread.js` (0 ⇒ already off main-thread) and `grep -rl __split__ src libs` (the codebase may already use it). The de-concat treemap is for finding importer *edges*, never for first-screen *share* of anything that might be split. Real first-screen share comes from the statoscope/rsdoctor stats of the optimized build, or the `__main-thread` entry treemap — not de-concat.
+
+**And `lazy(() => import())` does NOT remove bytes from `.lynx.bundle` by default — it can REGRESS it.** Measured: converting one tap-triggered popup to `lazy(() => import('../SomePopup'))` (ReactLynx's `lazy` works standalone — `Suspense` is *not* exported from the runtime, so don't import it) built fine and emitted a separate `output/static/js/SomePopup-react__*.js` chunk — but `.lynx.bundle` went **+223 KB**, not −155. Because **a Lynx page's `.lynx.bundle` is a self-contained bundle that packages its async chunks**; `import()` emits the separate (external) copy *and* keeps the content in `.lynx.bundle` → duplication + lazy-loader overhead + loss of any prior split dedup. The separate file only *replaces* the in-template copy when the build is configured to **externalize async chunks** (CDN upload via an async-chunk externalization plugin + the container loading them via a `loadLazyBundle`/`requireModule`-style API on demand). That externalization + the on-device runtime verification is **infra, not a source edit** — the same wall as externalizing the bundle. So: the deferral *prize* is real (stub the component to measure it), but neither `lazy(import)` nor `__split__` realizes it without the externalization infra turned on; a naive `lazy(import)` regresses `.lynx.bundle`. Don't ship it as a "lazy win" without measuring `.lynx.bundle` and confirming the chunk actually left it.
+
+**BUT — `__split__` (and "main-thread = 0") does NOT mean the code left `.lynx.bundle`.** Critical correction: `__split__` defers a component's *render* to the background thread, but its **code still ships in `.lynx.bundle`** (it lands in `background.js`, which is part of `.lynx.bundle = main-thread + background + css`). So "the popup is already split" is NOT "the popup is already removed from the first-screen bundle." To actually remove the bytes you need a **true dynamic/lazy component** — a separate Lynx bundle loaded on demand by the container (`@lynx-js/react/experimental/lazy/import`, or a platform dynamic-component API that ships ~0 in `.lynx.bundle`). **Measure the prize by stubbing the component at its consumer (`const X:any=()=>null`) and rebuilding — the `.lynx.bundle` drop is what a lazy bundle would save.** Real measured example: stubbing one tap-triggered fee/discount popup (`{hasFMP && <FeeDetailPopup __split__=...>}` — mounts after first paint) cut `.lynx.bundle` **−155.7 KB**, despite it already being split. A page's ~10 interaction-only popovers (UseRule, GoodsDetail, fee/discount, alerts) can hold **hundreds of KB** of deferrable first-screen weight that `__split__` alone does not remove. The cost is lazy-bundle infra (build each as a separate bundle + container loads on first tap = small latency), set up once then reused. **When `__split__` is in use, don't conclude "lazy lever applied" — `__split__` ≠ dynamic component; verify whether the bytes actually left `.lynx.bundle`.**

--- a/packages/skills/rspeedy-bundle-size/references/three-levers.md
+++ b/packages/skills/rspeedy-bundle-size/references/three-levers.md
@@ -1,0 +1,340 @@
+# The three size levers, and how to attack each
+
+After measuring (see [measure-with-rsdoctor.md](measure-with-rsdoctor.md)), the weight falls into three buckets. The technique is different for each. Always size all three first, then attack the biggest.
+
+## Contents
+
+- **[Lever 1 — Media assets](#lever-1--media-assets-usually-the-biggest-highest-roi)** — sizing, WebP/dedup/subset techniques, who fixes it (often CI).
+- **[Lever 2 — JS background thread](#lever-2--js-background-thread-tree-shaking-dedup)** — tree-shaking enablers, duplicate packages, **mangle failure / eval-poisoning**, the DCE≈0 reality check.
+- **[Lever 3 — Main-thread leakage](#lever-3--main-thread-leakage-background-only-code-in-the-render-path)** — jsb is background-only; the readable-`main-thread.js` finder; **trace on `concatenateModules:false`**; classify leaf/barrel/init/mixed/multi-importer; **macro-guard vs `import()`**; **`async`+es2015 *buries* `'background only'` → non-async wrapper**; **top-level fire-and-forget native call → `__BACKGROUND__`-guard**; runtime→compile-time macro; the last-reference rule; `pnpm patch` a library leak.
+- **[Lever 4 — Template / compile-layer knobs](#lever-4--template--compile-layer-knobs-lynx-specific-often-higher-roi-than-the-js-tail)** — `minify.css`, `extractStr`, debug-info; emitted-asset dedup; **i18n all-locales bloat** (don't lazy the active locale); font subset; **lazy bundle = first-screen lever, not total-size**.
+- **[Putting it together](#putting-it-together-a-prioritized-report)** — the prioritized three-layer report.
+
+> Quick rule of thumb: **media → background JS → main-thread leak → compile knobs**, but let the measured numbers reorder it. The single biggest measured bucket decides the engagement.
+
+---
+
+## Lever 1 — Media assets (usually the biggest, highest ROI)
+
+In real Lynx apps the single largest contributor is frequently **images**, not JS. Check this first.
+
+### How to size it
+Sum non-JS / asset modules from the moduleGraph, or inspect the output dir for image files. Look for:
+- Large PNGs that should be **WebP** (often 50–80% smaller at equal quality)
+- **Duplicated assets** — e.g. the same artwork shipped twice (a classic: an iOS and a non-iOS variant of one image that are near-identical)
+- Assets inlined as base64 that are large enough they should be external (or vice-versa)
+
+### Techniques
+| Problem | Fix |
+|---|---|
+| Big PNG/JPG | convert to WebP; quantize PNGs (pngquant) |
+| Same image twice | dedup; pick one variant or load conditionally at runtime |
+| Inline threshold wrong | tune the asset inline size limit |
+| Fonts shipped whole | subset to used glyphs |
+
+### Who fixes it
+Often the **CI/asset pipeline**, not app source — e.g. a build step that compresses/transcodes. Flag it as a pipeline change with an estimated saving; verify actual compressed sizes before promising a number.
+
+---
+
+## Lever 2 — JS background thread (tree-shaking, dedup)
+
+The `react:background` layer is app logic. This is where classic JS bundle optimization applies — but on a well-maintained project these wells are often **already dry**.
+
+### Tree-shaking enablers (check whether they're already done)
+- **`sideEffects: false`** in workspace libs that are actually side-effect-free. If a lib that should be tree-shakeable has `sideEffects: true`, whole modules survive unused.
+- **No `export *` barrels.** Barrel files (`index.ts` re-exporting everything) defeat tree-shaking and pull in the whole module. Prefer deep imports (`import { x } from 'lib/feature/x'`) over barrel imports (`import { x } from 'lib'`).
+- **`const enum` over `enum`** — `const enum` is inlined and leaves no runtime object; plain `enum` ships a lookup object. (Caveat: under `isolatedModules: true` — common in rspeedy/SWC projects, verified set in real repos — SWC does **not** inline `const enum` across files; it helps only same-file usages, so don't rely on it cross-module.)
+- **Free functions over class methods** when only one method is used — a class drags all its methods in.
+
+### Duplicate packages — often the single biggest JS lever in a monorepo
+The same library bundled at two versions doubles its cost; in a big monorepo this is frequently **tens of KB gzip** (a real project saw ~−40 KB gzip from one dedupe). Detect with `rsdoctor-agent packages duplicates`, or scan the lockfile / output for the same package name at two versions. Fix by **forcing a single copy via `resolve.alias`**:
+- Same/compatible version → `resolve.alias` the package to one resolved dir.
+- Multi-version where you must pin a specific one → a helper that locates the wanted version in the pnpm store and aliases to it (e.g. the project's `dedupAliasesAt({ 'pkg': '3.127.0' })` pattern). **Reuse the project's existing alias/dedupe helpers** rather than inventing new ones.
+- Risk: aliasing across a minor/major can break API or drop bundled resources the other version shipped — build + smoke-test after. Some dedupes get reverted for resource-compat reasons; check the project's history before re-enabling a commented-out one.
+
+### Mangle failure (eval poisoning) — a distinct size cause
+Sometimes the JS layer is large not because of *what* is included but because **names weren't compressed**. Symptom: a prettier-formatted production chunk (`dist/.rspeedy/main/background.<hash>.js`, `main-thread.js`) visibly contains readable **module-prefixed** names like `common_EVENT_NAME`, `utils_toSomething`, `foo_ExportedClass` — ModuleConcatenation artifacts that should have been mangled away.
+
+**Cause:** a single `eval()` anywhere inside a ModuleConcatenation (scope-hoisting) scope forces SWC to preserve *every* top-level name in that scope and its ancestors. With `optimization.concatenateModules: true` (rspack's production default), hundreds of modules share one scope, so one `eval()` de-mangles the whole bundle. Common offenders: `@protobufjs/inquire` (often via a protobuf wrapper lib), `js-md5`'s `nodeWrap`, `amdefine`, old `crypto-js`.
+
+**How to spot it fast:** grep the debug chunk for `eval(` — `0` is healthy, `>=1` is suspect. To prove it, minify the chunk twice (once with `eval(` replaced by `null&&(`) and compare sizes; a big drop confirms eval is the cause.
+
+**Fix directions (present as options, don't apply unilaterally):**
+- Remove the value import of the offender at the source (best when usages are few and app-local)
+- Alias the eval module to a shim (e.g. an `inquire` that `return null`) when it's shared across packages
+- Set `optimization.concatenateModules: false` to unblock immediately (+3–8% size, so it's a fallback not a fix)
+
+This is a deep topic; the above is enough to recognize, prove, and route it. If a chunk shows eval-poisoning, that usually dwarfs the structural tree-shaking wins above — check it before spending effort on barrels/dedup.
+
+### Reality check
+On an already-optimized project, code-level DCE (deleting unreachable code) typically nets **~0 at the bundle level** — the minifier already dropped it. `ts-prune` will report hundreds of "unused exports" but most are either entrypoints, type-only, or already shaken. Don't churn source for it. The wins here are structural (barrels, dedup, sideEffects), not line-by-line deletion.
+
+---
+
+## Lever 3 — Main-thread leakage (background-only code in the render path)
+
+The `react:main-thread` layer should be small — it's the first-screen render path. When background-only logic leaks into it, it inflates the main-thread bundle and the render cost. For *why* the main thread must stay lean (it does first-screen direct render + applies Patches; all logic/lifecycle/state lives on the background thread), see [dual-thread-architecture.md](dual-thread-architecture.md).
+
+### jsb is background-thread-ONLY — so ALL jsb in main-thread is dead, and its upper layer with it
+
+**Foundational fact (verify against the Lynx runtime, but treat as the default): JSB — `NativeModules`, the `.bridge.` object, `getJSModule(...)`, native `GlobalEventEmitter` — can only be called on the BACKGROUND thread.** The main/lepus thread has no JSB. Therefore **any jsb code that ends up in `main-thread.js` is dead by construction** — it can never run there — and so is **the upper-layer code that exists only to reach it** (the request/SDK/service glue that wraps a bridge call, the component logic whose only main-thread purpose was to set up a jsb call). That whole subtree is removable from main-thread; trace it and delete/guard it.
+
+**Stubbing the jsb imports on the main-thread layer (a build loader that swaps `import {...} from '<jsb-bridge-pkg>'` for no-op stubs) is a BAND-AID, not the fix — don't lead with it.** It removes the bytes (and is a fine way to *measure* the prize quickly), but it treats the symptom: the source code still imports and "calls" jsb on a thread where it can't run, and you've hidden that with a stub. The real fix is **dependency analysis: trace each jsb import chain to the source module that pulls it into the render path, and cut it there** — `__BACKGROUND__`-guard the jsb call/subscription, or move the jsb-using logic into a background-only module — so the subtree shakes *by construction* and the code honestly reflects that jsb is background-only. Use the stub-loader to quantify; ship the source-level cut. (This applies to the telemetry-strip loader in [assets/](assets/) too — measurement aid, not the principled fix.)
+
+This means a heavy jsb SDK sitting in `main-thread.js` is **not "render-needed, library-locked"** — it's a leak, even when the SDK ships a `*.lynx.js` build and is imported by many render components. Do NOT excuse it as "the main thread needs jsb" — it doesn't. Measured example (one real jsb bridge SDK): a `*.lynx.js` build (~137 KB, dozens of `.bridge.` + `NativeModules` + `getJSModule` calls, **zero `__BACKGROUND__` guards**) sat ~87 KB in main-thread, pulled in by render cards — all of it dead on the main thread. The fix is to background-gate it (patch the library so the bridge/jsb is `__BACKGROUND__`-only, or guard the importing upper layer), which DCEs the whole subtree from main-thread while the background thread keeps the real bridge. (Patching node_modules is fair game — `pnpm patch`.) The only caveat is the *contagion* the rest of this lever describes: you must remove **every** main-thread reference, and guard top-level consumers so a now-`undefined` bridge doesn't crash a main-thread module — but since jsb never worked on main-thread anyway, those consumers were already dead paths.
+
+**⭐ Verified empirical anchor (the gate works — gate it *selectively*, and know where it caps).** On a real app I library-gated the jsb SDKs by prepending `if(__MAIN_THREAD__)return;` to jsb functions and shipped it as `pnpm patch`es. Four things were proven:
+
+- **The macro substitutes inside `node_modules`.** A `MT_GATE_PROOF` sentinel confirmed `__MAIN_THREAD__` → `true` on the main-thread layer and `false` on background, *for library code* (0 raw `__MAIN_THREAD__` left in `main-thread.js`). So `if(__MAIN_THREAD__)return;` genuinely DCEs a library function's body on main-thread and keeps it on background — the gate is real (background `.bridge.` unchanged, 0 build errors).
+
+- **GATE SELECTIVELY — a jsb barrel is not all jsb.** A jsb bridge SDK's `*.lynx.js` build typically mixes jsb wrappers (each `return core.pipeCall({method:...})` — delegating to the bridge singleton) with **pure helpers** (`getRuntimeEnv` reads `lynx.__globalProps`, `canIUse`, `parseEnv`, version checks, babel-runtime `_extends`…). The pure helpers are **NOT jsb and run fine on main-thread**; gating them to `return;` would make first-screen env/feature checks return `undefined` — **a runtime bug a build with 0 errors will not catch.** Classify by whether the function body touches the bridge (`core.` / `.bridge` / `NativeModules` / `getJSModule` / `GlobalEventEmitter`); gate only those. A function-boundary-aware transform is in [assets/gate.awk](assets/gate.awk) (no babel needed) — but **`prettier --no-config --write` the lib's `.lynx.js` first**: it gates per-function *by line*, so on a raw compact build (`function f(){…}` on one line) it gates almost nothing and just warns (real-tested: raw → **1/77** gated; after prettier → **77/77 gated, output valid JS, pure helpers correctly kept**). Blanket-gating a whole barrel measured a larger drop but was **unsafe**; the **safe selective** gate (jsb-only) measured **~−0.4%** — the gap is exactly the pure helpers, which must not be touched. **`gate.awk` only sees top-level `function foo(){}` — a `GATED=0` is NOT proof the lib is jsb-free.** Libs that wrap jsb in **class methods or arrow exports** are invisible to it (real-tested: a class-method jsb lib gated **0/4** while calling `.bridge` / `getJSModule` / `NativeModules` — the script now warns "references jsb but GATED=0" in this case). For class/arrow-style libs, gate via a babel/SWC visitor (see [assets/plugin-strip-mt-telemetry.ts](assets/plugin-strip-mt-telemetry.ts) for the AST pattern), not the awk. Confirm the style first: `grep -c '^function ' lib.lynx.js` — near-zero means awk won't help.
+
+- **It caps at the wrappers; the bridge-core class is a floor.** The residual main-thread jsb (`this.bridge.call/on/off`, `NativeModules`) lives in an **ES6 class instantiated at module-init as a singleton** — a structural floor, same shape as a render engine referenced at init (see [rspeedy-gotchas §10](rspeedy-gotchas.md)). Gating call-site wrappers can't DCE a class the module constructs eagerly; you'd have to gate the **instantiation** (`__BACKGROUND__`-guard the `new`), cleanest done upstream. The de-concat's ~83 KB estimate was inflated (same over-attribution as icons: 870 KB est vs 441 KB real).
+
+- **Formalizing is version-fan-out, not one patch.** Several versions of one bridge lib (different libs pin different versions) were bundled into *one page's* main-thread → **multiple version-specific `pnpm patch`es**, each fragile (a dep bump can bundle a new unpatched version → half-gated, or drop the patched one → dead patch). The patches are small (only the ~220 changed signature lines, ~16 KB each), but the maintenance is real.
+
+**Takeaways:** the principled gate is viable and macros work in libraries, but (1) **gate selectively** — never blanket-gate a jsb barrel, it contains main-thread-safe helpers; (2) the leaf win is **small and capped** (~0.4% here) because the bridge singleton is a structural floor; (3) local patching is **version-fan-out + fragile**. Land the local patches for the immediate win if asked, but the durable fix is **upstream**: `__BACKGROUND__`-gate the bridge core at construction in the lib's `.lynx.js`, which shakes the whole subtree (class included) for every consumer at once.
+
+### What "leak" means
+Code that only needs to run on the background thread (network/jsb calls, loggers, heavy SDK glue) but got pulled into the main-thread layer because a render-path module imports it without a `'background only'` boundary. Note ReactLynx already auto-shakes `useEffect`/`componentDidMount`/`bindtap` callbacks out of `main-thread.js` — a leak is code the compiler *couldn't* statically attribute to one thread.
+
+### Best finder: read the readable prod `main-thread.js` and grep by module
+The most precise way to find leaks is to look at what's *actually* in the shipped main-thread bundle, with readable names and module paths:
+1. Build prod with **readable names + module paths**: `output.minify.mangle: false` (keep variable names — many projects already set this) **and** `tools.rspack.optimization.moduleIds: 'named'` (annotate each module with its source path). Add `DEBUG='rspeedy,rsbuild'` so the intermediate `main-thread.js` is kept (otherwise only the binary `.lynx.bundle` survives) — it lands at e.g. `output/.rspeedy/<page>/main-thread.js` (`find output -name main-thread.js` if a plugin relocated it).
+2. `prettier --no-config --write <main-thread.js>` to expand it to readable lines.
+3. Each module appears as `"(react:main-thread)/<source-path>"( __webpack_require__... ) { ... }`. **grep for background-only signatures and attribute each hit to its enclosing module** (the nearest `"(react:main-thread)/..."` above it): `NativeModules`, `GlobalEventEmitter`, `getJSModule`, `jsb`, `bridge` (the jsb-backed ones — always background-only), plus jsb-backed `sendReport`/`reportError`/logger calls, `\.request(`/`fetch(`, `mmkv`/`storage` (verify these aren't console-backed). A module full of these (e.g. `events.ts` = `ctx.getJSModule("GlobalEventEmitter").addListener(...)`) **should not be in main-thread at all** — it's a leak; trace its render importer and put it behind `'background only'`.
+
+> **Tools (automate steps 2–3):** [assets/mt-leak-analyzer.mjs](assets/mt-leak-analyzer.mjs) lists the de-concat `main-thread.js` modules with sizes, background-only flags, and importer edges (who pulls each in); [assets/mt-cutpoint-analyzer.mjs](assets/mt-cutpoint-analyzer.mjs) groups bytes by `"(react:main-thread)/<path>"` header to rank the heaviest leaked modules. **Both need the named-module debug format** (`(react:main-thread)/<path>` headers). A normal **production `main-thread.js` is concatenated + minified** (real-tested: 42 KB on **2 lines**, zero `react:main-thread` headers) → the analyzers report **`0 modules, 0 kB` and do NOT warn** — a false "no leak". You MUST feed them a `concatenateModules:false` build (then prettier it from step 1); verify with `grep -c react:main-thread main-thread.js` (0 = wrong input, re-build de-concat). (Fix side: [assets/gate.awk](assets/gate.awk) selectively gates jsb wrapper functions — see *GATE SELECTIVELY* above.)
+
+This beats stats analysis because it shows the *actual* main-thread content (post-shake, post-concat), not the pre-shake graph — you see exactly which background-only APIs survived into render, by module. A real audit found ~25 such modules: a render component that inlined a whole jsb/ad-video SDK (`bridge×126, jsb×26, NativeModules×6`), library loggers (a jsb logger client ×27), and small app utils (`events.ts`, `service.ts` request, `storage.ts`, a tracking call).
+
+### How to find it (alternative)
+From the moduleGraph (or `stats.json`), filter `layer === 'react:main-thread'`, drop asset modules (`.png/.zip/.m4a/...` — that's Lever 1), and keep code (`.ts/.tsx/.js/...`). Sort by `parsedSize`/`gzipSize`. Flag modules whose **basename** matches a background-only signature: `jsb`, `bridge`, `logger`/`report`/`monitor`/`track` (background-only when jsb-backed), `request`/`fetch`/`http`, `storage`/`mmkv`, `getJSModule`, `NativeModules`, `GlobalEventEmitter`, `protobuf`/`crypto`/`md5`. **Match the basename, not the full path** — every module under a `*-sdk/` dir contains "sdk" and will false-positive otherwise.
+
+> **stats.json is often too big to `readFileSync`.** A multi-entry app's merged `stats.json` can exceed 512 MB (V8's string limit) — a real one measured ~989 MB. It's pretty-printed (2-space indent), so stream it with `readline`: detect the root `"modules": [` line, then capture each top-level array element (lines starting at 4-space indent `    {` … `    }`), `JSON.parse` each independently, and recurse into its nested `modules`. Bounded memory, no giant string. (rsdoctor sharded data avoids this; see [measure-with-rsdoctor.md](measure-with-rsdoctor.md).)
+
+### ⚠️ Trace on a `concatenateModules: false` build — production edges lie
+**This is the make-or-break caveat.** rspack's production default scope-hoisting (`optimization.concatenateModules: true`) **collapses the `reasons`/importer edges**: a hoisted module's importer is reported as the whole concatenated group (`"./pages/x/index.tsx + 699 modules"`), not the actual file inside it. So on a production `stats.json` the importer graph is **wrong for every concatenated module**, and reachability/dominator analysis produces **false positives**. In a real audit `lodash.mergewith` (49.5 KB) looked like removable main-thread code; rebuilding with `optimization.concatenateModules: false` (via `tools.rspack`) restored the real edges and it correctly showed as render-reachable → **dropped out**. Always do importer tracing on a `concatenateModules:false` build (or on rsdoctor's graph, which is captured pre-hoist). Revert the config after.
+
+### Quantify first — set expectations before digging
+Before tracing, compute one number: **background-only code as a share of main-thread code.** On a real, already-optimized app (edge-accurate, no-concat build): cleanly-background-only modules reachable in main-thread were **~0.9% (~75 KB parsed of ~8 MB)** — and of that, the "bonus" non-signature code that *only* the trace finds (a utils barrel, a perf logger) was just **~11 KB**, with **0 KB cleanly app-deletable** (everything was `[also in background layer]`, i.e. fixable only at the definition site, usually an SDK lib). Looser path-based signatures inflate this to several percent but sweep in render code — don't. Expect **~1% of main-thread code on a tidy app, mostly library-gated**: quantify it, state it plainly, and don't oversell the lever.
+
+**Verify before claiming removable.** A module can look like a leak but actually be read during render. Typical pattern: a large shared-services module sits in the main-thread layer and *looks* removable, but tracing its importers shows many components render-read it → not removable. Often only some of its submodules (e.g. the `jsb`/`logger` parts) are truly dead on the main thread. Always trace before recommending a deletion.
+
+### Importer tracing is the real value
+
+The direct leaked API can be tiny (`getJSModule("GlobalEventEmitter")`, `NativeModules.bridge`, a logger, a request helper), but it is a **line of inquiry**, not just a byte count. Follow its callers/importers upward until you reach the render-path module that made the background-only code reachable from `react:main-thread`. That often reveals a larger pattern: a component imports a broad service/index module for one render-safe helper, and that service module also statically imports JSB, logging, storage, request, or SDK initialization code that main-thread will never execute.
+
+Do this as a small reverse-dependency audit:
+
+1. Pick suspicious main-thread modules by name/signature: `jsb`, `bridge`, `logger`, `request`, `storage`, `service`, `init`, `sdk`, `GlobalEventEmitter`, `NativeModules`, `getJSModule`.
+2. In `moduleGraph`, walk `imported` / reverse edges from that module toward entry modules. Stop when you hit app components, custom hooks, store setup, or SDK package entrypoints.
+3. Classify each edge:
+   - **render-read** — the component really reads the value during render; not removable wholesale.
+   - **handler/hook callback** — likely background-only if only triggered after interaction/effect; candidate for `'background only'`.
+   - **broad barrel/service import** — candidate for splitting imports or moving JSB/logger/request behind a background-only boundary.
+   - **library static import** — business app may not be able to fix it; route to library owners.
+4. Report both the immediate leak and the upstream owner/import path. A useful finding says "main-thread contains X because A → B → C imports it", not only "X appears in main-thread".
+
+**What the trace reveals: barrel re-exports** (the mechanism, even when the bytes are small). On the edge-accurate build, a clean chain was e.g. `src/common/utils/utils/index.ts` (a generic utils barrel, render-safe on its face) sitting in main-thread *only* because `request.ts` imports it, which is imported by an api barrel, imported by `reportPopupAck.ts` — i.e. a **report→api→request** chain ending at a barrel. The highest-leverage fix is **at the barrel**: deep-import the render-safe helper directly, or put the background-only exports behind a `'background only'` boundary, which removes the whole subtree from main-thread at once.
+
+Honest caveat from the same audit: this mechanism is real but the *measured* subtree was small (~11 KB beyond the signature modules) and `[also bg]`. The "small leak → large win" story is the upside to look for, not the expected outcome — on a tidy app you usually find the gate code itself plus a thin tail, not a giant hidden tree. Report what the bytes actually are.
+
+### Heuristic: event/lifecycle callbacks run on the background thread — mark them `'background only'` freely
+
+In Lynx, **events are triggered on the main thread but regular JS event handlers execute on the background thread** (the whole reason the two-thread split exists — see [Main Thread Script](https://lynxjs.org/react/main-thread-script.html)). So when you see a `handleXXX` / `onXXX` callback, an event-emitter listener (`addListener('exposure', this.handleExposure)`), or a lifecycle method (`componentDidMount`/`componentWillUnmount`) whose body is tracking/jsb/request/logger work, you can **boldly add `'background only'` as its first statement** — it's background-only by construction, so the marker is correctness-neutral and lets its background-only imports shake from main-thread. **One exception: if that function imports widely-*shared / cross-page* modules, use the `__MAIN_THREAD__`/`__BACKGROUND__` macro instead of the directive** — the directive adds a layer constraint that can de-concatenate those shared modules and *regress other pages* (measured +37.6 KB on a sibling page; see the ⚠️ on shared imports below).
+
+**The one exception: main-thread script (MTS).** A function declared with the `'main thread'` directive (first line) and bound via the `main-thread:bindXXX` attribute (e.g. `<view main-thread:bindscroll={onScroll} />`) runs *synchronously on the main thread* — for smooth animation / gesture handling. **Never mark an MTS function `'background only'`** (and the compiler won't let you call it from background). If a handler has `'main thread'` at the top or is bound through a `main-thread:` attribute, leave it alone. Everything else in the `handleXXX`/`onXXX` family is fair game. Full MTS reference: https://lynxjs.org/react/main-thread-script.html
+
+> Measured: marking the whole `handleExposure` exposure-listener `'background only'` held the **raw byte-identical** `.lynx.bundle` as wrapping its tracking block in `if (__BACKGROUND__)` — the directive removes the function's main-thread references just like the guard does. The byte win still only lands once the *last* reference to a given import is gone (see "The real rule" under the classification table) — directive vs guard is a style choice, not a strength difference.
+
+### ⚠️ The directive must survive compilation — `async` + a low syntax target *buries* `'background only'`
+
+`'background only'` only works when it stays the **first statement of a real function body the main-thread transform can see**. Two source shapes silently defeat that — the source still has the directive, the build has 0 errors, and the jsb import **stays in `main-thread.js` anyway** (a silent no-op that looks like "the lever didn't help"):
+
+1. **`async` function built to `es2015` (or lower).** A workspace lib compiled at `es2015` (the background-thread baseline; shared libs commonly pin it for the Lepus VM) lowers `async` to `__awaiter(..., function* () { ... })`, carrying the directive **into the inner generator** where the main-thread transform can't see it → no stub, no shake. **The tell:** in the *same* file a **non-`async`** function's directive works (its jsb shakes) while an `async` sibling's doesn't — that contrast proves the directive was buried, not that the lever is weak. **Fix — route the jsb call through a plain (non-`async`) `'background only'` wrapper**, and have every async helper call the wrapper:
+   ```ts
+   // ❌ es2015 build buries the directive in the __awaiter generator → jsb stays in main-thread
+   export const openPoiSchema = async (...args) => { 'background only'; return jsb.searchOpenSchema(...args); };
+   // ✅ plain non-async wrapper keeps the directive at the top of a real body → import shakes
+   const callSearchOpenSchema = (...args: Parameters<typeof jsb.searchOpenSchema>) => {
+     'background only';
+     return jsb.searchOpenSchema(...args);
+   };
+   // every async helper: jsb.searchOpenSchema(...) → callSearchOpenSchema(...)
+   ```
+   The wrapper is still *referenced* by main-thread-reachable async helpers, but its **body is stubbed**, so the jsb import drops. Same fix collapses a **transitive third-party** chain reached only via async callers (a real case also wrapped an `openShortLink` helper → shook its `shortlink` SDK → that SDK's `utils` dep). **App source built at the app's higher target keeps `async` + directive working — this trap is specific to the `es2015`-built *lib dist***, so library fixes go in the lib's `src/` then rebuild the lib before the app consumes them.
+2. **Expression-body arrow** (`async () => jsb.foo()`) has nowhere to host a leading statement. Convert to a block body with the directive first and an explicit `return`: `async () => { 'background only'; return jsb.foo(); }`.
+
+### A top-level fire-and-forget native call leaks its *whole transitive chain* — `__BACKGROUND__`-guard it
+
+A bare module-top-level side-effect call to a native/monitor registrar — `void registerPage({...})`, page/perf registration, reporters — runs at import time on **both** threads, dragging its **transitive** jsb chain into `main-thread.js` even though **there is no jsb-bridge import at the call site** (the jsb is several hops down: a real case had `registerPage` → a shared registration helper → a hybrid SDK → its jsb core). This is exactly the class a **signature grep on `main-thread.js` misses** — the leaked *module* is the jsb core, but the *fix point* is the unguarded top-level call, so a finder keyed on bridge/`NativeModules` at the call site won't flag it. Fix: move the call inside the module's existing `if (__BACKGROUND__) { ... }` block (the real fix moved the registration into the `__BACKGROUND__` guard already wrapping the page's other init). **Manual finder:** grep app entry/page modules for top-level `void someRegister(...)` / `initXxx()` not already under a `__BACKGROUND__` guard.
+
+### Classify the leak, then pick the matching fix — and remove *every* reference
+
+**⭐ Empirical anchor 2 — `__MAIN_THREAD__`-guard the CONSUMER functions; never use `import()` to "move" background-only code.** On a real app a de-concat + named build showed **232 KB of background-only modules in main-thread** (a network/request SDK incl a bundled 21 KB `package.json`, a btm SDK ~20 KB, monitors, loggers, `md5`, app `requester`/`monitor`/`reporter` glue). First mistake: I converted one btm-SDK use (in a `schema/index.ts` barrel imported by dozens of cards) to a **dynamic `import()`** → measured **.lynx.bundle +12.4 KB (WORSE)** and the SDK *stayed* in main-thread, because (a) `import()` adds a lazy-chunk + runtime overhead, and (b) the SDK had **other** main-thread references so it didn't shake (last-reference rule).
+
+**The right tool is `if (__MAIN_THREAD__) return;` on every consumer function** (the same gate as the jsb lever, applied *upward* to the app/lib code that calls the SDK). It DCEs the body on the main-thread layer — **zero added bytes, strictly cannot worsen the bundle** (no lazy chunk) — and once *all* main-thread references to the SDK are gated, the whole subtree shakes. Redoing the btm case that way: guarded the 2 consumer fns (the get-token + init-SDK helpers) → **.lynx.bundle −31.9 KB**, the SDK's jump-position helper gone from main-thread, intact in background, 0 errors. (`__MAIN_THREAD__`/`__BACKGROUND__` are real DefinePlugin macros, typed in `@lynx-js/react`; lint may need `// eslint-disable-next-line no-undef` and the codebase may spell it `__LEPUS__`.)
+
+**Three rules this teaches:** (1) to relocate background-only work off main-thread, **guard with the macro, don't `import()`** — dynamic import is for genuinely-lazy *render* code, and it *adds* bytes; (2) the **last-reference rule is absolute** — enumerate *every* main-thread consumer of the SDK and gate them all, or nothing shakes (use the de-concat importer graph to find them); (3) watch for the **init-time singleton** (`const requester = createRequester({...})` at module top-level) — gating the call-site functions won't shake it; you'd have to guard the construction too (`__MAIN_THREAD__ ? undefined : createRequester(...)`).
+
+**When the singleton is NOT safely gateable — and you must recognize this.** The same request SDK was the counter-example: gating its construction is **unsafe**, because (a) the module has **top-level side effects that access the singleton at import time** — `requester.interceptors.request.use(...)` runs on module load on *both* threads, so `undefined` on main-thread → **crash at page load**; (b) the singleton is **exported and accessed directly in 3 other modules across 2 more shared libs**; (c) callers rely on a `RetType.abort()` contract, so even a no-op stub must honor it. Safely gating it would need a hand-built stub (which *adds* bytes) plus guarding ~6 sites across 3 libs, with an **app-wide request-crash risk TypeScript can't catch** (the `undefined as Requester` cast hides every missed access). `~30 KB ≪ that blast radius` → **don't; fix it upstream** (lib shouldn't eager-construct + register interceptors at module top-level). The "strictly can't get worse" property of the macro guard holds for **pure leaf consumer functions** (btm) but **NOT** for a singleton woven with module-level side effects.
+
+**⭐ The cleanest gate of all — turn a RUNTIME thread-check into a COMPILE-TIME macro (zero behavior change, no stub).** Background-only singletons are often *already* guarded by a **runtime** check that happens to be thread-equivalent — e.g. `const Monitor = typeof NativeModules !== 'undefined' ? createMonitorInstance({...}) : null`. `NativeModules` is jsb, so it's `undefined` on the main thread → `Monitor` is **already `null` there at runtime** — but rspack can't *prove* the runtime check, so it bundles `createMonitorInstance` + its logger plugins into main-thread anyway. Add a compile-time macro to the condition — `__BACKGROUND__ && typeof NativeModules !== 'undefined'` — and rspack statically DCEs the SDK branch on the main-thread layer. **Runtime behavior is byte-for-byte identical** (still `null` on MT, unchanged on BG), there's no stub, and consumers already `Monitor?.x`-optional-chain. Measured −12.9 KB, correctness-neutral. **Always grep background-only SDK modules for `typeof NativeModules`, `if (!__LEPUS__)`, `if (__BACKGROUND__)`, `lynx.__globalProps`-based runtime thread/host checks gating a heavy construct — promoting them to a compile-time macro is the safest win on the board.** Do this *before* reaching for a stub.
+
+**Shared dependencies need ALL referencing SDKs gated (last-reference rule, at the dependency level).** One logger plugin was referenced by *both* the monitor config *and* the request config. Gating only one left the plugin in main-thread; the request stub alone moved only −1–3.7 KB, but **combined** with the monitor DCE it shook the logger plugin too — a super-additive −20.4 KB extra. When a shake "should" work but barely moves, grep the surviving symbol for its *other* importers and gate those too.
+
+**When you must stub a singleton (no existing runtime check), the stub must cover EVERY access form — grep-exhaustively.** Replacing `createRequester({...})` with a no-op stub on the `__MAIN_THREAD__` branch shook the request SDK safely — but only after the stub covered `interceptors / request / get / post / updateConfig` (the first version missed `get`/`post`, which `traffic.ts` calls at module level → would have crashed on MT). Grep every `<singleton>.<member>` across app+libs before trusting the stub; prefer the compile-time-macro or optional-chaining route when available because a missed method crashes at module load.
+
+**And the de-concat map systematically OVER-counts what's shakeable.** `concatenateModules:false` disables JSON tree-shaking, scope-hoist DCE, etc., so de-concat module sizes are inflated — repeatedly confirmed on one app: icons de-concat 870 KB vs real 441 KB; a request SDK's bundled `package.json` showed 21 KB in de-concat but removing it measured **Δ0** (prod already tree-shakes the JSON to its one used key); "background-only in MT" totaled 232 KB de-concat but the only clean realizable cut was the btm consumer gate (−31.9 KB). **Use de-concat to find importer edges and candidates, but quote only production `.lynx.bundle` before/after deltas as wins** — never the de-concat byte sizes. The realizable main-thread prize on a tidy app stays ~1%, and the rest needs upstream/architectural changes.
+
+**Empirical anchor (reversible experiment on a real app).** Tagging individual functions with `'background only'` — lifecycle callbacks, exposure/reach handlers, a data-fetch function, emitter on/off, etc. — moved `main-thread.js` only **~812 B raw / ~355 B gzip** (2,020,884 → 2,020,072 raw). It *looked* like the marker "doesn't cut the import graph" — but a later experiment proved otherwise: marking one whole callback (`handleExposure`) shook a whole bridge SDK (−33 KB gzip), raw byte-identical to a `__BACKGROUND__` guard. The reconciliation: in the 355 B run the tagged functions were **not the complete set of references** to the SDK imports they used — other unguarded render-path references (a sibling `throttle()` const, a util, a second component) kept the same imports alive, so nothing shook and only the body strings dropped. **The lesson is not "markers are weak" — it's "an import only shakes when its LAST main-thread reference is gone."** Tag/guard a few scattered functions and you'll see noise; enumerate and remove *all* references to a given import and the whole subtree drops. Always verify with a `.lynx.bundle` build, and don't report a single marker as a win until the import actually shook.
+
+So the trace's job is to **classify what kind of leak each finding is**, because the fix differs and only some are worth it:
+
+| Leak shape | What you see | Fix | Yield |
+|---|---|---|---|
+| **Leaf function** | one background-only fn inside a render module | `'background only'` directive (or `__BACKGROUND__` guard) | tiny (~hundreds of B) — usually not worth it alone |
+| **Barrel import** | render module deep-imports a barrel that also re-exports request/jsb/logger | split the import / deep-import the render-safe symbol directly | removes the subtree — the real win |
+| **Side-effect init** | a module run for its top-level effects (`initSdk()` at module scope), side-effect-imported by the app root | exported-fn + static binding import + top-level `if (__BACKGROUND__) { runInit() }` (see ✅ recipe below) | **real — measured ~−21 KB raw / ~−5.3 KB gzip** for one module; a naive `require()` guard *regresses* (see ⚠️) |
+| **render+lifecycle mixed module** | one React component module carries both render *and* background orchestration (requests, reach, listeners, popup init in `componentDidMount`) | **move the background orchestration into a separate module** | same — real fix is a refactor; verify with `.lynx.bundle` |
+| **multi-importer SDK** | a background-only library (jsb/bridge/logger SDK) shows up in main-thread because **several** render-path modules reference it (in handlers, exposure listeners, module-top `throttle(fn)` consts) | remove **every** main-thread reference — `if (__BACKGROUND__)` guard on the block, OR `'background only'` on a whole background callback (both remove the references; see rule below) — so DCE drops the named import everywhere → the whole SDK shakes | **the biggest single win measured — ~−72.6 KB raw / −33.0 KB gzip** for one bridge SDK (3 importers), control byte-identical. **Only feasible if you can enumerate+remove ALL main-thread references** — an SDK with ~30 importers (e.g. a core jsb bridge) is not app-side fixable; it needs the library itself to split by thread |
+
+> **The real rule (reconciles the two measurements below): an import shakes from main-thread iff you remove ALL of its main-thread references — and both a `'background only'` directive on a whole background function and an `if (__BACKGROUND__)` guard remove the references inside them (measured byte-identical: marking `handleExposure` `'background only'` shook a bridge SDK exactly as well as guarding its block — raw byte-identical).** The earlier "markers only saved ~355 B" result (below) was NOT the directive failing to cut the graph — it was tagging *some* functions while *other* unguarded references kept the same SDK imports alive, so nothing shook and only the body strings dropped. So: mark/guard freely, but you only get the byte win once the *last* reference to a given import is gone. Use a `__BACKGROUND__` guard when the surrounding function also has main-thread-needed code; use the `'background only'` directive when the **whole** function is background (cleaner, and the idiomatic Lynx way for `handleXXX`/`onXXX`/listeners/lifecycle — see the callback heuristic above).
+
+**Critical constraint: you cannot `import 'background-only'` from a main-thread module** — the build fails with *"background-only cannot be imported from a main-thread module."* So **side-effect-init and mixed-module leaks can't be marker-fixed; they must be split.** Typical pattern: an SDK-init module that runs `initSdk()/initOther()` at module top level and is side-effect-imported by the app root drags request/logger/popup/reach into main-thread — the fix is to separate the render-safe init from the background init, not to slap a directive on it.
+
+### Fixing a leak that lives in a `node_modules` library — measure first, then `pnpm patch`
+
+When the leaking module is a third-party/SDK package, you don't have to "route to the owner and wait" — you can patch the installed package directly: **`pnpm patch <pkg>@<ver>`** (or your monorepo's `pnpm patch` passthrough) opens an editable copy, you add the `'background only'` directive / `__BACKGROUND__` guard to the offending function, then **`pnpm patch-commit <dir>`** writes a `.patch` and registers it in `patchedDependencies`. One patch fixes the leak for **all** importers at once — the library-split the multi-importer row says you "need" can be done locally. (Measured: patching one logger SDK's unguarded `sendLog`/`init` methods to `'background only'` → −6.5 KB raw / −3.0 KB gzip, control byte-identical. Persistence in a monorepo can be tooling-specific — some setups store the `.patch` under a gitignored temp dir and rewrite the lock to a hash ref — so confirm the team's patch-commit flow before relying on it across clones.)
+
+**But measure the per-package main-thread footprint BEFORE patching — most heavy `node_modules` in main-thread are NOT leaks.** Build the readable `main-thread.js` (mangle:false + moduleIds:'named'), then sum bytes between consecutive `"(react:main-thread)/<path>"` markers, grouped by package. What this reveals on a real app:
+- The scary "core SDK imported by 500+ modules" (e.g. a jsb bridge) is often **already tree-shaken out of main-thread** — it doesn't even appear in the top-N. Importer count ≠ main-thread weight. The jsb wrappers are reached only from background, so they're already gone; patching them buys nothing.
+- A logger SDK may **already guard its heavy client** with `if (!__LEPUS__)` / `if (__BACKGROUND__)` in its constructor — no leak to fix (and watch out: a naïve signature grep counts a `webXxxLogger` *property name* as a logger leak — a false positive).
+- The genuinely-heavy main-thread `node_modules` are usually **render UI component libraries** (countdown, modal, rolling-number, button…), generic utils, and lodash — these are *legitimately* on the main thread because they render, so they're **not** background-only-patchable. The lever for them is dedup (multi-version lodash) or lazy-loading (first-screen), not `'background only'`.
+- Beware the **concatenation attribution trap**: a scope-hoisting group root (e.g. `tslib.es6.mjs`) can show an absurd size (1 MB+) because inlined modules with no own marker get credited to it. Cross-check suspicious giants against a `concatenateModules:false` build before believing them.
+
+Net: the `pnpm patch` lever is real but its *upside is small on a tidy app*, because the big main-thread `node_modules` are render UI, not leaked background code. Confirm a package is both heavy in main-thread **and** genuinely background-only before spending a patch on it.
+
+> ⚠️ **The naive "split" can make the shipped binary BIGGER — measured.** A tempting quick fix is to replace the static side-effect `import './initSdk'` with a guarded runtime require: `if (!__LEPUS__) { require('./initSdk') }`. It *does* DCE the subtree out of the main-thread layer — but a runtime `require()` **defeats ModuleConcatenation (scope-hoisting)**: the subtree that was hoisted/minified into the entry scope becomes individually-wrapped modules on the *background* side. In a real reversible experiment this made one page's `.lynx.bundle` go **1,705,232 → 1,728,170 gzip (+22.9 KB gzip)** — a net **regression**, because `.lynx.bundle` ships both layers and the de-concatenation cost outweighed the main-thread removal. Always measure `.lynx.bundle` before/after; "removed it from main-thread.js" is not the same as "shrank the shipped bundle."
+
+> ⚠️⚠️ **The `'background only'` DIRECTIVE can de-concatenate shared modules across OTHER pages — use a `__MAIN_THREAD__`/`__BACKGROUND__` macro instead. Measured both ways.** Marking a module that imports **widely-shared utilities** with the `'background only'` directive (or IIFE) adds a *layer constraint* that forces those shared modules out of scope-hoisting in **every** page bundle that uses them — even pages that don't import your module (they're coupled through the shared module + global ModuleConcatenation). The macro ternary is plain define-substitution → DCE, with **no layer tag**, so concatenation survives.
+>
+> Real measured case — 4 redux **effect** defs (`defineEffects(atom, {...})` at module top, all consumers background):
+> | form | target page (task) gzip | sibling page (sign, doesn't import effects) gzip |
+> |---|---|---|
+> | `(() => { 'background only'; return defineEffects(...) })()` (directive IIFE) | −4.2 KB | **+37.6 KB** ❌ |
+> | `__MAIN_THREAD__ ? (undefined as never) : defineEffects(...)` (macro) | **−5.7 KB** ✅ | **−12.0 KB** ✅ |
+>
+> The directive→macro swing on the sibling page was **−49.7 KB gzip**. The macro form improved *both* pages (−17.7 KB total). The `(undefined as never)` keeps the type clean (`never | T` collapses to `T`, callers need no cast), and it's a one-line edit (no IIFE close).
+>
+> **Rules:** (1) To strip a module's main-thread footprint when it imports **shared/cross-page** code, use `__BACKGROUND__ ? value : undefined` / `__MAIN_THREAD__ ? undefined : value` (pure DCE) — **never** the `'background only'` directive. (2) Always measure **every** page, not just the target: a previously byte-stable control page suddenly moving is the de-concatenation tell. (3) The `'background only'` directive is still fine for code importing **page-local / genuinely-isolated** SDKs (that's why the page-local bridge SDK and `handleExposure` cases were clean — control byte-identical); the danger is specifically shared imports. When unsure which, the macro is the safe default — it never adds a layer constraint.
+
+> ✅ **The recipe that works — static ESM + `__BACKGROUND__`, no `require()` (measured ~−21 KB raw / ~−5.3 KB gzip for one init module).** Keep concatenation intact by never introducing a runtime require. Two steps:
+> 1. **Wrap the module's top-level side effects in an exported function** so the module body is side-effect-free: `export function runInit() { initSdk(); initOther(); }` (no top-level execution left).
+> 2. In the consuming render module, switch the bare `import './initSdk'` to a **binding import** and **call it from a top-level `if (__BACKGROUND__)` guard**: `import { runInit } from './initSdk'` … then at module top level `if (__BACKGROUND__) { runInit(); }`.
+>
+> Main-thread: `__BACKGROUND__` is `false` → the guarded call is DCE'd → the binding is unused → and because step 1 made the module body side-effect-free, rspack's `optimization.sideEffects` (on by default in prod) **auto-detects** it and shakes the whole subtree from main-thread. Background: `__BACKGROUND__` is `true` → init runs at module-eval time, same as the original (no behavior change). All imports stay static ESM, so concatenation is preserved — no de-hoisting penalty.
+>
+> Notes: **Step 1 is the load-bearing part** — `sideEffects:false` alone, *without* extracting the init, would just drop the side effects on background too (breaks it). And once the module *is* side-effect-free, you usually **don't need an explicit `sideEffects` flag** — verified byte-identical with and without a `tools.rspack.module.rules: [{test:/initSdk\.ts$/, sideEffects:false}]` entry. (Keep the explicit flag only if auto-detection is conservative for a stubborn module, e.g. a re-export barrel.) Prefer the **top-level `if (__BACKGROUND__)` guard over `componentDidMount`** — the lifecycle defers init past first render (a behavior change); the top-level guard preserves import-time timing for the same byte win. Use the canonical macro `__BACKGROUND__` / `__MAIN_THREAD__` (the `__JS__` / `__LEPUS__` forms are deprecated aliases — verified in lynx-stack `packages/react/runtime/types`).
+
+> ✅ **Variant — a top-level singleton (`export const x = new Service()`).** Same problem (the `new` is a top-level side effect that pins the module + class in main-thread even when `x` is only used in background), same cure. Wrap just the construction in a `'background only'` IIFE so it strips on main-thread:
+> ```ts
+> export const reachService = (() => {
+>   'background only';
+>   return new ReachService();
+> })();
+> ```
+> Main-thread strips the IIFE body → `new` and the `ReachService` class shake out; background constructs it normally. The IIFE form keeps the return **type** (`ReachService`) with no cast — cleaner than `export const x = (__BACKGROUND__ ? new Service() : undefined) as Service`. Measured ~−10 KB raw / ~−4.5 KB gzip for one singleton (control page byte-identical). Prerequisite, as always: every use of `x` must already be in a background context (lifecycle/handlers) — if render reads it, it stays. **And if `ReachService` (or anything it imports) pulls in a widely-shared / cross-page module, the `'background only'` IIFE will de-concatenate it across other pages (the +37.6 KB regression above) — use the macro form `(__BACKGROUND__ ? new ReachService() : undefined) as ReachService` there instead.**
+
+The compile-time macros `__BACKGROUND__` and `__MAIN_THREAD__` (the older `__JS__` / `__LEPUS__` are deprecated aliases) guard a block the compiler can't attribute on its own (details in [dual-thread-architecture.md](dual-thread-architecture.md) §代码裁剪). A `__BACKGROUND__` guard and a `'background only'` directive both **remove the references inside them** from the main-thread graph — the import they fed shakes once *every* reference to it is gone (see "The real rule" above). Guard a *block* when the surrounding function still has main-thread work; mark the *whole function* `'background only'` when it's entirely background (the idiom for `handleXXX`/`onXXX`/listeners); guard a *top-level import-driving call / construction* (the init/singleton recipes above) to shake a whole subtree at module scope.
+
+### `'background only'` is contagious — and that's the lever
+Marking one thing background-only **propagates**: everything it imports becomes background-shakeable, and every place that *uses* it must itself be in a background context (or it pins the thing back into main-thread). So the productive loop is to **follow the chain upward and mark layer by layer** — a background-only service → its background-only callers → their background-only modules — each marking lets the next subtree shake out of `react:main-thread`. The wins compound across layers far more than any single guard. Practical loop: from the main-thread `stats.json`, find a background-only seed (jsb/request/logger/report/reach/a service singleton), confirm all its main-thread uses are already background, mark it, **measure `.lynx.bundle`**, then move one layer up the importer chain and repeat until a real render consumer blocks you.
+
+> ⚠️ **Guarding a value to background-only forces you to guard its top-level consumers too — this is correctness, not just optimization.** If you do `export const svc = (() => { 'background only'; return new Svc() })()`, then on the main thread `svc` is **`undefined`**. Any *top-level* code that uses it (e.g. a sibling `Object.entries(map).forEach(([k,cb]) => svc.register(k, cb))` registration block) will run on the main thread and **crash** with `undefined.register(...)`. So you must wrap that consumer block in `if (__BACKGROUND__) { ... }` as well. This (a) removes the crash and (b) shakes the consumer block *and the functions it references* (the registration callbacks, their imports) out of main-thread too — the recursive "mark one layer, the next layer falls" win in action. Always grep the module for *other top-level uses* of anything you just made background-only, and guard them in the same change.
+
+**The biggest chains are third-party.** The heaviest leaks usually trace into shared SDK libraries (jsb/request/logger glue) reached via a handful of entry components (widgets, promotion entries, reach HOCs). Real removal needs the **library** to split a render-safe entry from its background entry — app-side single-point edits can't fix it. Report it as a library ask with the entry component named.
+
+For the directive's semantics and accepted forms, defer to the `reactlynx-best-practices` skill (`detect-background-only` rule) — don't re-derive them here.
+
+### This lever is a trace workflow, not a "see leakage → add `'background only'`" reflex
+1. From main-thread stats/product, find JSB / logger / request / storage modules.
+2. Reverse-trace to the business caller (on a `concatenateModules:false` build — see the ⚠️ above).
+3. Classify the leak: leaf function · barrel import · side-effect init · render/lifecycle-mixed module.
+4. Apply the matching fix from the table — markers for leaves (rarely worth it), import-split or module-split for the rest.
+5. **Verify the byte delta with one build.** Never report the marker/edit as a win without before/after numbers.
+
+---
+
+## Lever 4 — Template / compile-layer knobs (Lynx-specific, often higher ROI than the JS tail)
+
+`.lynx.bundle` = `tasm encode(main-thread.js + background.js + cssMap)`. Beyond the JS graph there are **compile-layer knobs** that shrink the binary directly. These are usually a few config lines and frequently beat grinding the main-thread-leakage tail. Each is a candidate to **measure** (estimates below are rough — verify with a build):
+
+- **CSS minify — `output.minify.css`.** Lynx projects often set `minify: { css: false }` (fear of breaking the scoped-CSS / tasm pipeline). CSS is encoded into `.lynx.bundle`; if unminified, all whitespace/comments/long class names ship. Flipping to `true` can be a large win on CSS-heavy pages (est. tens of KB gzip). **Risk: style breakage** — measure bytes *and* verify rendering. Note `pluginReactLynx` may also force `minify.css:false` when `enableRemoveCSSScope:false` (a guard) — check that interaction.
+- **String extraction — `pluginReactLynx({ extractStr: true })`.** Duplicated string literals are hoisted into a **shared table** (stored once, referenced from both main-thread and background) → fewer duplicates in `.lynx.bundle`. **Just set `extractStr: true`** — tuning the `strLength` threshold is generally **not** recommended (the default is already tuned; lowering it has diminishing returns and can regress from index overhead). Low risk; measure the before/after.
+- **Debug info — `debugInfoOutside` / debug-info level.** Debug metadata can be large; placing it outside the template (or trimming its level) reduces shipped size. Confirm the project's setting.
+- **ES target (`output.environment`)** — covered in [rspeedy-gotchas.md](rspeedy-gotchas.md) §1: a project forced to full ES5 pays a size premium vs es2015/es2019 (one project estimated ~+143 KB raw / ~+12 KB gzip for full-ES5). Engine-driven, usually not movable, but quantify it before assuming it's free.
+
+### Duplicate emitted resources (images/lotties) in the output
+Even when media is served from a CDN (external to `.lynx.bundle`), the **build can emit the same image content as multiple files**, and the same asset is often duplicated across an app + the SDKs it bundles (e.g. a sign-in-modal background present in several sign-in SDKs, animation frames in the app + multiple shared static-asset SDKs). To find it: hash (`md5`) every emitted image under the output dir, group by content hash, rank duplicate groups by `size × (copies-1)`. Real audits found ~tens of MB of source-side duplicate copies. Caveats: (1) contenthash asset pipelines often auto-dedupe identical content — **verify in the *output*, not just source**, since source dups may collapse; (2) if the dups are external CDN assets, deduping shrinks download/CDN footprint and runtime fetches, not `.lynx.bundle` itself — still a real "perceived bundle" win, just be precise about which number moves.
+
+### ⭐ i18n: all-locales statically bundled into the render path (often the single biggest app-side chunk)
+
+A recurring, high-value leak in Lynx apps: the i18n setup **statically bundles every language** into the bundle — and because i18n is used in render, the locale JSON lands in **`main-thread.js` AND `background.js`** (duplicated → shipped ~twice in `.lynx.bundle`). The tell in source:
+
+```ts
+const localesContext = import.meta.webpackContext('./locales', { regExp: /\.json$/ });  // eager → all 57 langs bundled
+// ... resources: Object.fromEntries(localesContext.keys().map(...))   // registers every locale
+```
+
+**How to spot it:** (1) grep app source for `import.meta.webpackContext(` / `import.meta.glob(` pointing at a `locales` dir, or a `locales/` dir with many `.json`; (2) build readable `main-thread.js` (moduleIds:'named') and group module bytes by path — if `src/i18n/locales/*` dominates, this is it. On a real app **`src/i18n/locales/*` was 2.34 MB = 87% of a 2.64 MB `main-thread.js`**, and the same ~2.3 MB was *also* in `background.js`.
+
+**Measured win** (build with only the `en` locale to approximate active-locale-only, warm cache): one app dropped **−1093 kB / −12.9%** of `.lynx.bundle` across 5 pages (one page 5479.8 → 4981.5). This is usually the **largest single app-side lever** on an i18n-heavy app — far bigger than any leakage/config tail.
+
+**⚠️ Do NOT "fix" this by lazy-loading the locales — the active locale is first-screen-direct-render content.** The tempting fix (switch the context to lazy mode, `await import` the active language) is **wrong**: the main thread renders translated text on the **first-screen direct render**, so the active locale is needed *synchronously at first paint*. Lazy-splitting it forces a dynamic chunk load *during* first-screen render → the first screen gets **slower** (or flashes untranslated text). This is the general rule (see the lazy-bundle lever below): **never lazy-split anything the first-screen direct render needs** — and i18n's active locale is exactly that. (An "only `en` bundled" build is a useful way to *measure the prize* — it showed the −1093 kB above — but it is **not a shippable fix**; it just deletes the other languages.)
+
+**So what IS first-screen-safe?** The bloat is the *duplication* (every language, in *both* layers), not the active locale itself. First-screen-safe ways to claim it:
+- **`extractStr`** dedups the duplicated main/background locale strings into one shared table — **no defer, no first-screen cost** (strings stay synchronously available, stored once). This is precisely its job and the cleanest fix *when it's permitted*.
+- **Host-injected active locale:** some containers can hand the active locale's resource to the page synchronously via globalProps; then no languages need to ship in the bundle and first screen stays synchronous. This is an **architecture change** (needs host cooperation), not an app-only edit.
+- The 56 *non-active* languages are first-screen-irrelevant, but you **can't statically pick which one is active** (it's runtime `appLocale`), so you can't selectively keep "the active one" eager while lazying the rest.
+
+Net: **quantify the i18n bloat (it's often the biggest single chunk — found in ~5–6 projects of one fleet, each 57 locales, one with an anomalously huge baseline), but realize it via `extractStr`/host-injection, NOT lazy.** Without one of those, it's an honest wall — report the size and the required change, don't ship a first-screen regression.
+
+### Font subsetting — `pluginFontmin`
+Inlined/subsetted fonts can be sizable. An over-broad subset inlines a big `.ttf`; an under-broad `text` set white-boxes glyphs. Check whether fonts are inlined into the template and whether the subset is right-sized.
+
+### Lazy bundle / dynamic components — a FIRST-SCREEN lever, NOT a total-size lever
+ReactLynx 3 supports a dynamic loader (`IS_RL3_DYNAMIC_LOADER`) + lazy components. Splitting **non-first-screen surface** (popups, modals, drawers, secondary-activity SDKs) out of the initial `.lynx.bundle` makes the **first-screen download smaller** and load faster. First screen typically needs only header + primary content + main list; everything triggered later can be lazy.
+
+> ⚠️ **Measured: lazy bundle shrinks the initial template but INCREASES total download.** The lazy API works — `import { lazy } from '@lynx-js/react/experimental/lazy/import'`, `const X = lazy(() => import('./X'))`, used **standalone** (`Suspense` is **not** exported by the ReactLynx runtime — verified against `@lynx-js/react`, whose main entry exports neither `Suspense` nor `lazy`; don't wrap it, see [rspeedy-gotchas.md §11](rspeedy-gotchas.md)) — and produces a real loadable lazy template at a separate lazy bundle under `output/.../async/<path>/`. On a real app, lazy-splitting **one** component: initial page `.lynx.bundle` **−204 KB raw / −85 KB gzip**, but a new lazy bundle **+382 KB raw / +144 KB gzip** appeared → **total +177 KB raw / +59 KB gzip**. The lazy bundle is a **standalone template that re-includes framework runtime/wrapper overhead** (~178 KB raw / ~59 KB gzip of it in that experiment), so it's *bigger* than what left the main template. **So: if the goal is total/whole-app size, lazy bundle is the wrong tool (it makes total worse). If the goal is first-screen render/initial download, it's a strong lever.** Be explicit which metric you're optimizing before reaching for it.
+>
+> **Consolidate into FEW BIG lazy bundles, not many small ones.** The overhead is roughly *fixed per lazy bundle* (the framework runtime re-inclusion), independent of component size. So splitting one 200 KB component costs ~the same overhead as splitting a 600 KB cluster — splitting N small components pays the overhead N times. Find the **single biggest deferrable cluster** (the component/barrel with the largest *exclusive subtree* — compute it: for each candidate the main entry imports, exclusive-subtree = modules reachable normally minus modules still reachable with that candidate cut) and split *that* as one bundle. On a real app the biggest deferrable single entry was the **popups barrel (645 KB parsed exclusive)** — ~3× a single popup component — but note a side-effect-registration barrel needs the on-demand registration (dialog manager) to lazy-load per component, more work than lazy-loading a single rendered component.
+
+> **Lazy a LOCAL default-export component, not a package named-export that shares the package with static imports.** Measured: splitting a clean local component (`const X = lazy(() => import('./X'))`) moved its full exclusive subtree (−204 KB raw). Splitting a package named-export — `const NewTaskWidget = lazy(() => import('@pkg').then(m => ({default: m.NewTaskWidget})))` — moved only ~82 KB raw (vs 301 KB estimated), because another static `import { RewardTypeEnum } from '@pkg'` kept most of `@pkg` in the main template; only the part *exclusive to that one export* moved. So when a candidate is a package named-export, either (a) split the whole package's import site, or (b) expect a much smaller move than the cluster size suggests. Combined first-screen for two rendered components: **−110 KB gzip off `.lynx.bundle`, +79 KB gzip total** (two lazy bundles' overhead).
+
+**Size the deferrable surface before anything else — it's usually the headline number.** Method: from the build `stats.json`, take all code modules (main + background), drop `node_modules` (framework, hard to defer), and bucket the business modules by path into **deferrable** (name/path matches `popup|modal|drawer|dialog|treasure|fission|share|reward|coupon|appointment|redpack|lottery|sign-in|watch-video|widget|cross-zone|new-user|prize|giftbox|...`) vs **core**. Sum each; rank the deferrable clusters by size. On a real already-JS-optimized app this came out to **framework 49% / business-core 24% / business-deferrable 26% (~5.3 MB parsed)** — i.e. a quarter of the code was non-first-screen UI, dwarfing the ~tens-of-KB from every leakage/config lever combined. Biggest clusters were sign-in / generic popups / watch-video / widget / treasure-box.
+
+**That's the size of the prize; realizing it is architectural, not a quick win.** Hard caveats:
+1. **"Deferrable by name" ≠ truly non-first-screen** — some modals auto-pop on load. You must confirm each cluster is only rendered after interaction (product/runtime knowledge, not static analysis — don't guess; lazy-loading a first-screen modal breaks UX).
+2. **`lazy(() => import('./X'))` does work in ReactLynx** (verified — emits a separate lazy bundle under `output/.../async/<path>/`, loaded on demand by the dynamic loader). Import `lazy` from `@lynx-js/react/experimental/lazy/import` and use it **standalone** — `Suspense` is **not** exported by the ReactLynx runtime (see [rspeedy-gotchas.md §11](rspeedy-gotchas.md)). (`experimental_isLazyBundle` is the separate *standalone* lazy-bundle mode for cross-build/CDN-published components — not needed for in-app splits.)
+3. **Watch for fake lazy.** A `lazy(() => Promise.resolve({ default: AlreadyImported }))` defers *rendering*, not *loading* — the component is still statically bundled, so it saves **zero** bytes. If that's the only `lazy()` in the repo, there's no real code-split precedent, but real `lazy(() => import())` still works.
+4. Shared SDKs imported wholesale need their import site split.
+
+So: quantify the surface early (cheap — sets expectations and is often the headline number), but treat realization as an infra/architecture project gated on (a) a real per-cluster "is this first-screen?" answer and (b) a working lazy-bundle+CDN path — not an autonomous code tweak.
+
+---
+
+## Putting it together: a prioritized report
+
+After sizing all three:
+
+```
+Total: 14.2 MB
+├─ Media        10.1 MB  ← attack first (WebP + dedup → est. -6 MB)
+├─ JS bg         3.0 MB  ← already tree-shaken; dedup nets ~-50 KB
+└─ JS main       1.1 MB  ← ~65 KB is app-side leak (fixable), rest is in SDK libs (library ask)
+```
+
+Lead with the table. The biggest lever decides the engagement; everything else is secondary.


### PR DESCRIPTION
## What

Adds a new skill **`rspeedy-bundle-size`** (`@lynx-js/skill-rspeedy-bundle-size`) — a measure-first workflow for analyzing and reducing the bundle size of rspeedy/Lynx (ReactLynx) apps.

## Contents

- **SKILL.md** — measure-first workflow, the three-layer/three-lever mental model, when (not) to use it.
- **references/**
  - `dual-thread-architecture.md` — why there are two JS layers; what the build emits (`<name>.lynx.bundle`).
  - `three-levers.md` — media / background-JS / main-thread-leakage, plus compile-layer knobs (`extractStr`, CSS minify, i18n duplication, lazy bundles).
  - `rspeedy-gotchas.md`, `measure-with-rsdoctor.md`, `cross-project-triage.md`.
  - `assets/` — leak/cutpoint analyzers, a selective jsb gate (`gate.awk`), a telemetry-strip loader/plugin, a source triage scanner, and shared `signatures.cjs` (customizable per stack).
- **evals/** — 10 task evals (30 expectations) + 22 trigger evals. `check_evals` passes (definition_score=100).

## Notes

- Background-only mechanism is framed around **jsb-backed** APIs; logger/telemetry signals are flagged as background-only **only when jsb-backed** (console-backed logging runs on the main thread too).
- Size metric is the shipped **`.lynx.bundle`**; signature lists in the assets are generic placeholders meant to be customized per project's telemetry/SDK stack.

Draft — opening for review of scope and genericization before marking ready.