### PR TITLE
chore: export rspeedy bundle size skill

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@lynx-js/skill-lynx-typescript": "workspace:*",
     "@lynx-js/skill-lynx-ui": "3.133.4",
     "@lynx-js/skill-reactlynx-best-practices": "workspace:*",
+    "@lynx-js/skill-rspeedy-bundle-size": "workspace:*",
     "@lynx-js/skill-vanilla-lynx": "workspace:*"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       '@lynx-js/skill-reactlynx-best-practices':
         specifier: workspace:*
         version: link:packages/skills/reactlynx-best-practices
+      '@lynx-js/skill-rspeedy-bundle-size':
+        specifier: workspace:*
+        version: link:packages/skills/rspeedy-bundle-size
       '@lynx-js/skill-vanilla-lynx':
         specifier: workspace:*
         version: link:packages/skills/vanilla-lynx
@@ -210,6 +213,8 @@ importers:
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
+
+  packages/skills/rspeedy-bundle-size: {}
 
   packages/skills/vanilla-lynx: {}
 

--- a/scripts/validate-skills.test.mjs
+++ b/scripts/validate-skills.test.mjs
@@ -23,6 +23,7 @@ const ALLOWED_PREFIXES = [
   'reactlynx-',
   'ttml-',
   'perflab-',
+  'rspeedy-',
   'vanilla-lynx',
 ];
 const ALLOWED_PREFIX_RE = new RegExp(


### PR DESCRIPTION
## Summary
- Add `@lynx-js/skill-rspeedy-bundle-size` to the root marketplace dependencies.
- Update `pnpm-lock.yaml` so the workspace package is linked for export.

## Validation
- `pnpm check`
- `pnpm build` (confirmed `@lynx-js/skill-rspeedy-bundle-size` is exported)