### PR TITLE
fix: downgrade devtool changeset from minor to patch

### DIFF
--- a/.changeset/add-lynx-devtool-packages.md
+++ b/.changeset/add-lynx-devtool-packages.md
@@ -1,7 +1,7 @@
 ---
-"@lynx-js/devtool-connector": minor
-"@lynx-js/devtool-mcp-server": minor
-"@lynx-js/skill-lynx-devtool": minor
+"@lynx-js/devtool-connector": patch
+"@lynx-js/devtool-mcp-server": patch
+"@lynx-js/skill-lynx-devtool": patch
 ---
 
 Add the Lynx DevTool packages: `@lynx-js/devtool-connector` (device transport layer with background daemon), `@lynx-js/devtool-mcp-server` (MCP server exposing DOM/CSS/Runtime/Performance and more tools), and an updated `@lynx-js/skill-lynx-devtool` skill with screenshot, console, heap snapshot, recorder, and ReactLynx inspection commands.

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -4,7 +4,6 @@
   "commit": false,
   "fixed": [
     [
-      "@lynx-js/devtool-connector",
       "@lynx-js/devtool-mcp-server",
       "@lynx-js/skill-lynx-devtool"
     ]

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -2,12 +2,7 @@
   "$schema": "https://unpkg.com/@changesets/config@3.1.2/schema.json",
   "changelog": "@changesets/cli/changelog",
   "commit": false,
-  "fixed": [
-    [
-      "@lynx-js/devtool-mcp-server",
-      "@lynx-js/skill-lynx-devtool"
-    ]
-  ],
+  "fixed": [["@lynx-js/devtool-mcp-server", "@lynx-js/skill-lynx-devtool"]],
   "linked": [],
   "access": "public",
   "baseBranch": "main",


### PR DESCRIPTION
- Change devtool packages version bump from minor to patch
- Remove `@lynx-js/devtool-connector` from the fixed version group