### PR TITLE
fix(skill-lynx-devtool): bundle daemon-entry and inspector wrapper

### DIFF
--- a/.changeset/skill-daemon-entry-bundle.md
+++ b/.changeset/skill-daemon-entry-bundle.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/skill-lynx-devtool": patch
+---
+
+Bundle the connector daemon entry and inspector wrapper into the skill build so `DaemonTransport` can resolve `#daemon-entry` and the inspector UI assets are available at runtime.

--- a/.gitignore
+++ b/.gitignore
@@ -151,6 +151,7 @@ dist
 
 # auto-generated skill and plugin files
 packages/skills/*/scripts
+packages/skills/*/public
 packages/plugins/*/skills
 packages/plugins/*/scripts
 packages/plugins/*/.claude-plugin

--- a/packages/skills/lynx-devtool/package.json
+++ b/packages/skills/lynx-devtool/package.json
@@ -2,9 +2,16 @@
   "name": "@lynx-js/skill-lynx-devtool",
   "version": "0.13.3",
   "type": "module",
+  "bin": {
+    "lynx-devtool": "./scripts/index.mjs"
+  },
+  "imports": {
+    "#daemon-entry": "./scripts/daemon-entry.mjs"
+  },
   "files": [
     "SKILL.md",
     "scripts",
+    "public",
     "references",
     "examples",
     "reference.md",
@@ -17,6 +24,7 @@
   "devDependencies": {
     "@lynx-js/devtool-connector": "workspace:*",
     "@rslib/core": "catalog:rstack",
+    "@rspack/core": "catalog:rstack",
     "@types/node": "24",
     "commander": "14",
     "core-js": "^3.49.0",

--- a/packages/skills/lynx-devtool/rslib.config.ts
+++ b/packages/skills/lynx-devtool/rslib.config.ts
@@ -4,6 +4,7 @@
 
 import path from 'node:path';
 import { defineConfig } from '@rslib/core';
+import { CopyRspackPlugin } from '@rspack/core';
 
 const buildTime = new Date();
 const formattedBuildTime = `${buildTime.getFullYear()}-${String(buildTime.getMonth() + 1).padStart(2, '0')}-${String(
@@ -18,6 +19,8 @@ export default defineConfig({
     entry: {
       index: './src/index.ts',
       connector: './src/connector.ts',
+      'daemon-entry':
+        './node_modules/@lynx-js/devtool-connector/src/daemon/entry.ts',
     },
     define: {
       'process.env.NODE_ENV': JSON.stringify('production'),
@@ -46,6 +49,16 @@ export default defineConfig({
           preserveModules: path.resolve(import.meta.dirname, 'src/commands'),
         },
       },
+      plugins: [
+        new CopyRspackPlugin({
+          patterns: [
+            {
+              from: './node_modules/@lynx-js/devtool-connector/public',
+              to: path.resolve(import.meta.dirname, 'public'),
+            },
+          ],
+        }),
+      ],
     },
   },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,6 +19,9 @@ catalogs:
     '@rslib/core':
       specifier: 0.19.2
       version: 0.19.2
+    '@rspack/core':
+      specifier: 1.7.0
+      version: 1.7.0
     '@rstest/core':
       specifier: 0.7.9
       version: 0.7.9
@@ -256,6 +259,9 @@ importers:
       '@rslib/core':
         specifier: catalog:rstack
         version: 0.19.2(@microsoft/api-extractor@7.56.2(@types/node@24.10.10))(typescript@5.9.3)
+      '@rspack/core':
+        specifier: catalog:rstack
+        version: 1.7.0(@swc/helpers@0.5.18)
       '@types/node':
         specifier: '24'
         version: 24.10.10

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,6 +11,7 @@ catalogs:
   rstack:
     '@rslib/core': 0.19.2
     '@rsbuild/core': 1.7.1
+    '@rspack/core': 1.7.0
     '@rstest/core': 0.7.9
   adb:
     '@yume-chan/adb': ^2.6.0


### PR DESCRIPTION
The skill bundles @lynx-js/devtool-connector into its own scripts/, so DaemonTransport's #daemon-entry resolution and the inspector UI need their artifacts bundled too. Add the daemon-entry rslib entry, copy the connector's public/ (inspector-wrapper.html) via CopyRspackPlugin, declare the #daemon-entry imports map and bin, and gitignore the generated public/ output. Add @rspack/core to the rstack catalog.