### PR TITLE
fix(build-plugin): honor package manifest opt-in for package.json

### DIFF
--- a/.changeset/build-plugin-package-json-opt-in.md
+++ b/.changeset/build-plugin-package-json-opt-in.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/skill-lynx-devtool": patch
+---
+
+Include package.json in published files so the `#daemon-entry` subpath import resolves correctly after the skill is exported from the workspace.

--- a/packages/cmd/build-plugin/package.json
+++ b/packages/cmd/build-plugin/package.json
@@ -15,7 +15,8 @@
     }
   },
   "scripts": {
-    "build": "rslib build"
+    "build": "rslib build",
+    "test": "node --test 'test/**/*.test.mjs'"
   },
   "dependencies": {
     "npm-packlist": "^5.1.3"

--- a/packages/cmd/build-plugin/src/lib.ts
+++ b/packages/cmd/build-plugin/src/lib.ts
@@ -2,13 +2,30 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 
-import { copyFile, mkdir, stat, writeFile } from 'node:fs/promises';
+import { copyFile, mkdir, readFile, stat, writeFile } from 'node:fs/promises';
 import { dirname, resolve } from 'node:path';
 import { default as packList } from 'npm-packlist';
 
+async function packageFilesIncludesPackageJSON(pkgDir: string) {
+  const pkg = JSON.parse(
+    await readFile(resolve(pkgDir, 'package.json'), 'utf-8'),
+  ) as { files?: unknown };
+
+  return (
+    Array.isArray(pkg.files) &&
+    pkg.files.some(
+      (file) =>
+        typeof file === 'string' &&
+        file.replaceAll('\\', '/').replace(/^\.\//, '') === 'package.json',
+    )
+  );
+}
+
 /**
  * Copy files in a package (defined by package.json `files`)
- * to target dir, should mirror the behavior of `npm pack`
+ * to target dir, should mirror the behavior of `npm pack`.
+ * When skipPackageJSON is true, package.json is copied only if `files`
+ * explicitly includes package.json.
  * @param pkgDir path of dir of the package
  * @param targetDir copy to
  */
@@ -18,12 +35,12 @@ export async function copyPackageFiles(
   skipPackageJSON: boolean = false,
 ) {
   const files = await packList({ path: pkgDir });
+  const skipImplicitPackageJSON =
+    skipPackageJSON && !(await packageFilesIncludesPackageJSON(pkgDir));
 
   for (const file of files) {
-    if (skipPackageJSON) {
-      if (file === 'package.json') {
-        continue;
-      }
+    if (skipImplicitPackageJSON && file === 'package.json') {
+      continue;
     }
     const sourcePath = resolve(pkgDir, file);
     const targetPath = resolve(targetDir, file);

--- a/packages/cmd/build-plugin/test/copy-package-files.test.mjs
+++ b/packages/cmd/build-plugin/test/copy-package-files.test.mjs
@@ -1,0 +1,61 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import assert from 'node:assert/strict';
+import { existsSync } from 'node:fs';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { after, test } from 'node:test';
+
+import { copyPackageFiles } from '../src/lib.ts';
+
+const tempDirs = [];
+
+async function makePackage(files) {
+  const dir = await mkdtemp(join(tmpdir(), 'build-plugin-copy-'));
+  tempDirs.push(dir);
+
+  await writeFile(
+    join(dir, 'package.json'),
+    JSON.stringify(
+      {
+        name: 'test-package',
+        version: '1.0.0',
+        files,
+      },
+      null,
+      2,
+    ),
+  );
+  await writeFile(join(dir, 'SKILL.md'), '# Test Skill\n');
+
+  const target = join(dir, 'out');
+  await mkdir(target);
+  return { source: dir, target };
+}
+
+after(async () => {
+  await Promise.all(
+    tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })),
+  );
+});
+
+test('copies package.json when package files explicitly include it', async () => {
+  const { source, target } = await makePackage(['package.json', 'SKILL.md']);
+
+  await copyPackageFiles(source, target, true);
+
+  assert.equal(existsSync(join(target, 'SKILL.md')), true);
+  assert.equal(existsSync(join(target, 'package.json')), true);
+});
+
+test('skips package.json when package files do not explicitly include it', async () => {
+  const { source, target } = await makePackage(['SKILL.md']);
+
+  await copyPackageFiles(source, target, true);
+
+  assert.equal(existsSync(join(target, 'SKILL.md')), true);
+  assert.equal(existsSync(join(target, 'package.json')), false);
+});

--- a/packages/skills/lynx-devtool/package.json
+++ b/packages/skills/lynx-devtool/package.json
@@ -2,13 +2,14 @@
   "name": "@lynx-js/skill-lynx-devtool",
   "version": "0.13.3",
   "type": "module",
-  "bin": {
-    "lynx-devtool": "./scripts/index.mjs"
-  },
   "imports": {
     "#daemon-entry": "./scripts/daemon-entry.mjs"
   },
+  "bin": {
+    "lynx-devtool": "./scripts/index.mjs"
+  },
   "files": [
+    "package.json",
     "SKILL.md",
     "scripts",
     "public",
@@ -23,8 +24,8 @@
   },
   "devDependencies": {
     "@lynx-js/devtool-connector": "workspace:*",
-    "@rslib/core": "catalog:rstack",
-    "@rspack/core": "catalog:rstack",
+    "@rslib/core": "^0.23.0",
+    "@rspack/core": "^2.0.8",
     "@types/node": "24",
     "commander": "14",
     "core-js": "^3.49.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,14 +17,11 @@ catalogs:
       version: 2.6.1
   rstack:
     '@rslib/core':
-      specifier: 0.19.2
-      version: 0.19.2
-    '@rspack/core':
-      specifier: 1.7.0
-      version: 1.7.0
+      specifier: 0.23.0
+      version: 0.23.0
     '@rstest/core':
-      specifier: 0.7.9
-      version: 0.7.9
+      specifier: 0.10.6
+      version: 0.10.6
 
 importers:
 
@@ -115,7 +112,7 @@ importers:
     devDependencies:
       '@rslib/core':
         specifier: catalog:rstack
-        version: 0.19.2(@microsoft/api-extractor@7.56.2(@types/node@24.10.8))(typescript@5.9.3)
+        version: 0.23.0(@microsoft/api-extractor@7.56.2(@types/node@24.10.8))(core-js@3.49.0)(typescript@5.9.3)
       '@types/node':
         specifier: '24'
         version: 24.10.8
@@ -137,7 +134,7 @@ importers:
     devDependencies:
       '@rslib/core':
         specifier: catalog:rstack
-        version: 0.19.2(@microsoft/api-extractor@7.56.2(@types/node@24.10.8))(typescript@5.9.3)
+        version: 0.23.0(@microsoft/api-extractor@7.56.2(@types/node@24.10.8))(core-js@3.49.0)(typescript@5.9.3)
       '@types/node':
         specifier: '24'
         version: 24.10.8
@@ -153,7 +150,7 @@ importers:
     devDependencies:
       '@rslib/core':
         specifier: catalog:rstack
-        version: 0.19.2(@microsoft/api-extractor@7.56.2(@types/node@24.13.2))(typescript@5.9.3)
+        version: 0.23.0(@microsoft/api-extractor@7.56.2(@types/node@24.13.2))(core-js@3.49.0)(typescript@5.9.3)
       '@types/node':
         specifier: ^24.13.2
         version: 24.13.2
@@ -177,7 +174,7 @@ importers:
         version: 5.0.0
       rsbuild-plugin-publint:
         specifier: ^1.0.0
-        version: 1.0.0(@rsbuild/core@1.7.1)
+        version: 1.0.0(@rsbuild/core@2.0.15(core-js@3.49.0))
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -193,7 +190,7 @@ importers:
         version: 1.29.0(zod@3.25.76)
       '@rslib/core':
         specifier: catalog:rstack
-        version: 0.19.2(@microsoft/api-extractor@7.56.2(@types/node@24.13.2))(typescript@5.9.3)
+        version: 0.23.0(@microsoft/api-extractor@7.56.2(@types/node@24.13.2))(core-js@3.49.0)(typescript@5.9.3)
       core-js:
         specifier: ^3.49.0
         version: 3.49.0
@@ -202,7 +199,7 @@ importers:
         version: 2.1.3
       rsbuild-plugin-publint:
         specifier: ^1.0.0
-        version: 1.0.0(@rsbuild/core@1.7.1)
+        version: 1.0.0(@rsbuild/core@2.0.15(core-js@3.49.0))
       zod:
         specifier: ^3.25.76
         version: 3.25.76
@@ -231,7 +228,7 @@ importers:
     devDependencies:
       '@rslib/core':
         specifier: catalog:rstack
-        version: 0.19.2(@microsoft/api-extractor@7.56.2(@types/node@24.10.10))(typescript@5.9.3)
+        version: 0.23.0(@microsoft/api-extractor@7.56.2(@types/node@24.10.10))(core-js@3.49.0)(typescript@5.9.3)
       '@types/node':
         specifier: ^24.10.4
         version: 24.10.10
@@ -243,7 +240,7 @@ importers:
     devDependencies:
       '@rslib/core':
         specifier: catalog:rstack
-        version: 0.19.2(@microsoft/api-extractor@7.56.2(@types/node@24.10.10))(typescript@5.9.3)
+        version: 0.23.0(@microsoft/api-extractor@7.56.2(@types/node@24.10.10))(core-js@3.49.0)(typescript@5.9.3)
       '@types/node':
         specifier: ^24.10.4
         version: 24.10.10
@@ -257,11 +254,11 @@ importers:
         specifier: workspace:*
         version: link:../../mcp-servers/devtool-connector
       '@rslib/core':
-        specifier: catalog:rstack
-        version: 0.19.2(@microsoft/api-extractor@7.56.2(@types/node@24.10.10))(typescript@5.9.3)
+        specifier: ^0.23.0
+        version: 0.23.0(@microsoft/api-extractor@7.56.2(@types/node@24.10.10))(core-js@3.49.0)(typescript@5.9.3)
       '@rspack/core':
-        specifier: catalog:rstack
-        version: 1.7.0(@swc/helpers@0.5.18)
+        specifier: ^2.0.8
+        version: 2.0.8(@swc/helpers@0.5.23)
       '@types/node':
         specifier: '24'
         version: 24.10.10
@@ -284,13 +281,13 @@ importers:
         version: 7.56.2(@types/node@24.10.10)
       '@rslib/core':
         specifier: catalog:rstack
-        version: 0.19.2(@microsoft/api-extractor@7.56.2(@types/node@24.10.10))(typescript@5.9.3)
+        version: 0.23.0(@microsoft/api-extractor@7.56.2(@types/node@24.10.10))(core-js@3.49.0)(typescript@5.9.3)
       '@rstest/adapter-rslib':
         specifier: ^0.1.1
-        version: 0.1.1(@rslib/core@0.19.2(@microsoft/api-extractor@7.56.2(@types/node@24.10.10))(typescript@5.9.3))(typescript@5.9.3)
+        version: 0.1.1(@rslib/core@0.23.0(@microsoft/api-extractor@7.56.2(@types/node@24.10.10))(core-js@3.49.0)(typescript@5.9.3))(typescript@5.9.3)
       '@rstest/core':
         specifier: catalog:rstack
-        version: 0.7.9
+        version: 0.10.6(core-js@3.49.0)
       '@types/node':
         specifier: ^24.10.4
         version: 24.10.10
@@ -513,14 +510,14 @@ packages:
   '@changesets/write@0.4.0':
     resolution: {integrity: sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q==}
 
-  '@emnapi/core@1.8.1':
-    resolution: {integrity: sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg==}
+  '@emnapi/core@1.10.0':
+    resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
 
-  '@emnapi/runtime@1.8.1':
-    resolution: {integrity: sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==}
+  '@emnapi/runtime@1.10.0':
+    resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
 
-  '@emnapi/wasi-threads@1.1.0':
-    resolution: {integrity: sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==}
+  '@emnapi/wasi-threads@1.2.1':
+    resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
   '@esbuild/aix-ppc64@0.27.2':
     resolution: {integrity: sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw==}
@@ -808,26 +805,11 @@ packages:
       '@cfworker/json-schema':
         optional: true
 
-  '@module-federation/error-codes@0.22.0':
-    resolution: {integrity: sha512-xF9SjnEy7vTdx+xekjPCV5cIHOGCkdn3pIxo9vU7gEZMIw0SvAEdsy6Uh17xaCpm8V0FWvR0SZoK9Ik6jGOaug==}
-
-  '@module-federation/runtime-core@0.22.0':
-    resolution: {integrity: sha512-GR1TcD6/s7zqItfhC87zAp30PqzvceoeDGYTgF3Vx2TXvsfDrhP6Qw9T4vudDQL3uJRne6t7CzdT29YyVxlgIA==}
-
-  '@module-federation/runtime-tools@0.22.0':
-    resolution: {integrity: sha512-4ScUJ/aUfEernb+4PbLdhM/c60VHl698Gn1gY21m9vyC1Ucn69fPCA1y2EwcCB7IItseRMoNhdcWQnzt/OPCNA==}
-
-  '@module-federation/runtime@0.22.0':
-    resolution: {integrity: sha512-38g5iPju2tPC3KHMPxRKmy4k4onNp6ypFPS1eKGsNLUkXgHsPMBFqAjDw96iEcjri91BrahG4XcdyKi97xZzlA==}
-
-  '@module-federation/sdk@0.22.0':
-    resolution: {integrity: sha512-x4aFNBKn2KVQRuNVC5A7SnrSCSqyfIWmm1DvubjbO9iKFe7ith5niw8dqSFBekYBg2Fwy+eMg4sEFNVvCAdo6g==}
-
-  '@module-federation/webpack-bundler-runtime@0.22.0':
-    resolution: {integrity: sha512-aM8gCqXu+/4wBmJtVeMeeMN5guw3chf+2i6HajKtQv7SJfxV/f4IyNQJUeUQu9HfiAZHjqtMV5Lvq/Lvh8LdyA==}
-
-  '@napi-rs/wasm-runtime@1.0.7':
-    resolution: {integrity: sha512-SeDnOO0Tk7Okiq6DbXmmBODgOAb9dp9gjlphokTUxmt8U3liIP1ZsozBahH69j/RJv+Rfs6IwUKHTgQYJ/HBAw==}
+  '@napi-rs/wasm-runtime@1.1.4':
+    resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -845,91 +827,96 @@ packages:
     resolution: {integrity: sha512-edgyN2pP07uXiP4tJs0s8KVmU8M8i60YPbbI0/WDeok1mIJHRXz+CgD8I0nelwDkoCh3EWL/G5kGfbuHjsdbvw==}
     engines: {node: '>=18'}
 
-  '@rsbuild/core@1.7.1':
-    resolution: {integrity: sha512-ULIE/Qh+Ne80Pm/aUPbRHUvwvIzpap07jYNFB47azI8w5Q3sDEC4Gn574jsluT/42iNDsZTFADRBog9FEvtN9Q==}
-    engines: {node: '>=18.12.0'}
+  '@rsbuild/core@2.0.15':
+    resolution: {integrity: sha512-O8vmMhZu1YImO6jOqt/K/vlJSvkq7UtSq5YM1DIlcEd9LW8Gf6/dkQ1B2KPI6F+hSMFBnTTTumdcIowSLCw97g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
+    peerDependencies:
+      core-js: '>= 3.0.0'
+    peerDependenciesMeta:
+      core-js:
+        optional: true
 
-  '@rslib/core@0.19.2':
-    resolution: {integrity: sha512-eoRR1tQqkEiq3ijBT170KpxnBM7nf3/sanAUoJhyCeyLKKkGpQW6nr1cKHfZmkEizqSvLyjvLFA7fdIfK7pCMw==}
-    engines: {node: '>=18.12.0'}
+  '@rslib/core@0.23.0':
+    resolution: {integrity: sha512-OEn5iNKYIyoy0JEUOXH2UTPBKlQRy/RjOtODhC4vS/sIw9iE8Nsp/4s0aeOkNtxsenuuxZCZo2foYvilI7VRgg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
       '@microsoft/api-extractor': ^7
-      typescript: ^5
+      typescript: ^5 || ^6
     peerDependenciesMeta:
       '@microsoft/api-extractor':
         optional: true
       typescript:
         optional: true
 
-  '@rspack/binding-darwin-arm64@1.7.0':
-    resolution: {integrity: sha512-HMYrhvVh3sMRBXl6cSI2JqsvlHJKQ42qX+Sw4qbj7LeZBN6Gv4GjfL3cXRLUTdO37FOC0uLEUYgxVXetx/Y4sA==}
+  '@rspack/binding-darwin-arm64@2.0.8':
+    resolution: {integrity: sha512-vCgbgH7B7qom+uID+RCZsTCOYFb9wC4/4+1U6rMfytrXGVJ72eNQs2tbdjOl0lb18CT3N/n+VkWynUiLk84GwA==}
     cpu: [arm64]
     os: [darwin]
 
-  '@rspack/binding-darwin-x64@1.7.0':
-    resolution: {integrity: sha512-R/SoR04ySmHPqoIBGC+SjP9zRGjL1fS908mdwBvQ1RfFinKu7a/o/5rxH/vxUUsVQrHCyX+o7YXpfWq9xpvyQA==}
+  '@rspack/binding-darwin-x64@2.0.8':
+    resolution: {integrity: sha512-satPm2PD4B7jDTVlVAdvMVdUszwLvWUEnUDzLb77mvVkezKNDZmuhb+e8s+FfKs8hJpNbZ9VAejuA2rr8o985w==}
     cpu: [x64]
     os: [darwin]
 
-  '@rspack/binding-linux-arm64-gnu@1.7.0':
-    resolution: {integrity: sha512-jDCcso++qshu58+Iuo6oiL0XKuX04lDugL0qwrWHW8SS/EjZ2rc1J3yQx+XDW0PCQsfI2c9ji0IOW56PzW1hXQ==}
+  '@rspack/binding-linux-arm64-gnu@2.0.8':
+    resolution: {integrity: sha512-pSI+npPQE/uDtiboqvcOIRJbEV2+B+H1xffmko/gw50la92oTUW60kVULFwsb6L0+GVCzIcwX3yq60GtYIn+Ug==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@rspack/binding-linux-arm64-musl@1.7.0':
-    resolution: {integrity: sha512-0W49s0SQQhr3hZ8Zd7Auyf2pv4OTBr6wQhgWUQ6XeeMEjB16KpAVypSK5Jpn1ON0v9jAPLdod+a255rz8/f3kg==}
+  '@rspack/binding-linux-arm64-musl@2.0.8':
+    resolution: {integrity: sha512-igjJ43yxWQ72GZqjDDZSSHax9/Vg+6rLMmOvFglTJUkQpB4Tyvu/YjW+WRjYj2xRw6blOjLxUSJWASvuSqqlvg==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@rspack/binding-linux-x64-gnu@1.7.0':
-    resolution: {integrity: sha512-oFjzjTD1MmG0ucAaP0Wyg9eobrsnFwZjEHa7LwyzWDRBeC3GWAF9T04Bqd6Ba6DgASGzU0BjEJcUpjvtXxO95Q==}
+  '@rspack/binding-linux-x64-gnu@2.0.8':
+    resolution: {integrity: sha512-zrkoEOnqj1hOEBO5T2I/2Ts2HSJsYFh1qXwMpK4dMJFGGNWDfNeUa6/LF5uq3VINF3JUl7RL47AgrucoSZJXPA==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@rspack/binding-linux-x64-musl@1.7.0':
-    resolution: {integrity: sha512-MNGslPLOsurdwOcoo6r0u8mLpw1ADar3hkx67WzwwMqYnem/Ky0aANJC2JvQHPC22mu01gCOukHYyEaUFTxcuw==}
+  '@rspack/binding-linux-x64-musl@2.0.8':
+    resolution: {integrity: sha512-6CtDaGZjNDvJd9TBp7a9zABbrPORO21W96+3ZcGBn0YNUPUk4ARxIxrTTpeJ/1F41QDM8AYIkGDdqEYMqTYBsA==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@rspack/binding-wasm32-wasi@1.7.0':
-    resolution: {integrity: sha512-eaZzkGpxzVESmaX/UALMiQO+eNppe/i1VWQksGRfdoUu0rILqr/YDjsWFTcpbI9Dt3fg2kshHawBHxfwtxHcZQ==}
+  '@rspack/binding-wasm32-wasi@2.0.8':
+    resolution: {integrity: sha512-Yf4SiqTUroT5Ju+te0YAY2xxKOb35tECsO21v7hYyGa705wrgoAK/MmF7enOvs9GR1iZIqgiLD/wxsIxl8GjJw==}
     cpu: [wasm32]
 
-  '@rspack/binding-win32-arm64-msvc@1.7.0':
-    resolution: {integrity: sha512-XFg4l7sOhupnpG0soOfzYLeF2cgpSJMenmjmdzd9y06CotTyVId0hNoS7y+A7hEP8XGf3YPbdiUL5UDp6+DRBA==}
+  '@rspack/binding-win32-arm64-msvc@2.0.8':
+    resolution: {integrity: sha512-8NCuiQsAhXrwRBy57QZoypqrws/zLBkaQVGiB8hksr6v++8hNigNjqpQARLbd0iyMuHsQQ++8+auGk6xlDXmzw==}
     cpu: [arm64]
     os: [win32]
 
-  '@rspack/binding-win32-ia32-msvc@1.7.0':
-    resolution: {integrity: sha512-eWt2XV6la/c0IlU/18RlhQsqwHGShSypwA3kt4s/dpfOK0YB1h4f0fYeUZuvj2X0MIoJQGhMofMrgA35/IcAcw==}
+  '@rspack/binding-win32-ia32-msvc@2.0.8':
+    resolution: {integrity: sha512-bxiekytbX7V9KFAra+HkwtNWC6pYfHEBBZFpiT0xUs3mCFOmAAFVBsBSQsoCP9AdCEXoMAvNdnrHNw3iov4OZw==}
     cpu: [ia32]
     os: [win32]
 
-  '@rspack/binding-win32-x64-msvc@1.7.0':
-    resolution: {integrity: sha512-LOL5G8rfbAwlmusx+t98r9QzuGRz+L9Bg+8s5s6K/Qe64iemcNIuxGr5QLVq1jLa0SGNTeog4N21pAzlkWh4jw==}
+  '@rspack/binding-win32-x64-msvc@2.0.8':
+    resolution: {integrity: sha512-7zPs8YCe/ZVJTwd+5lpB0CP0tkn2pONf/T1ycmVY76u21Nrwt8mXQGc/2yH2eWP4B7fikYBr3hGr7mpR2fajqQ==}
     cpu: [x64]
     os: [win32]
 
-  '@rspack/binding@1.7.0':
-    resolution: {integrity: sha512-xO+pZKG2dvU9CuRTTi+DcCc4p+CZhBJlvuYikBja/0a62cTntQV2PWV+/xU1a6Vbo89yNz158LR05nvjtKVwTw==}
+  '@rspack/binding@2.0.8':
+    resolution: {integrity: sha512-3uZ+y8aQxq33ty2srMxg2Nu0XuBI6vVrG50rkDaXqwWqOohfgGUSfFuQK7EnSUNy4aFUQlCG6NHialQHJov0wg==}
 
-  '@rspack/core@1.7.0':
-    resolution: {integrity: sha512-uDxPQsPh/+2DnOISuKnUiXZ9M0y2G1BOsI0IesxPJGp42ME2QW7axbJfUqD3bwp4bi3RN2zqh56NgxU/XETQvA==}
-    engines: {node: '>=18.12.0'}
+  '@rspack/core@2.0.8':
+    resolution: {integrity: sha512-+NLGJf8gZxihDmMFzjlly3toc2SMjeDmuvz0/Cai9AMdV4F+Pqcnt2BA9V4e3SY2jmhJQtPwgyyLtR1RiJO77g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
-      '@swc/helpers': '>=0.5.1'
+      '@module-federation/runtime-tools': ^0.24.1 || ^2.0.0
+      '@swc/helpers': ^0.5.23
     peerDependenciesMeta:
+      '@module-federation/runtime-tools':
+        optional: true
       '@swc/helpers':
         optional: true
-
-  '@rspack/lite-tapable@1.1.0':
-    resolution: {integrity: sha512-E2B0JhYFmVAwdDiG14+DW0Di4Ze4Jg10Pc4/lILUrd5DRCaklduz2OvJ5HYQ6G+hd+WTzqQb3QnDNfK4yvAFYw==}
 
   '@rstest/adapter-rslib@0.1.1':
     resolution: {integrity: sha512-R63E/DrtG4ol9wffAxgeq9ze6/Dm9wms0S6grm8maXAQ7qLooza/CTj4AH6aXeEjbpb64hfRGZy8VmZh9+fCfg==}
@@ -940,12 +927,12 @@ packages:
       typescript:
         optional: true
 
-  '@rstest/core@0.7.9':
-    resolution: {integrity: sha512-RHNPS1MDUxtf+1Z0YZi+vIQ13SdvCbcbpzDA7XHcPziTRy2mAPg8nfcms+XzbIp95KXH75ucAhgAKNFO0QgARA==}
-    engines: {node: '>=18.12.0'}
+  '@rstest/core@0.10.6':
+    resolution: {integrity: sha512-nX61dw2Tnxfwy/jGZEuNbh2tzapgaH6Iwj4Aw5d2wxUwxptUL3ddUxFF5M1ZSWoLEVG30VaPg3ITzrSo5sdbTg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
-      happy-dom: '*'
+      happy-dom: ^20.8.3
       jsdom: '*'
     peerDependenciesMeta:
       happy-dom:
@@ -983,8 +970,8 @@ packages:
   '@rushstack/ts-command-line@5.2.0':
     resolution: {integrity: sha512-lYxCX0nDdkDtCkVpvF0m25ymf66SaMWuppbD6b7MdkIzvGXKBXNIVZlwBH/C0YfkanrupnICWf2n4z3AKSfaHw==}
 
-  '@swc/helpers@0.5.18':
-    resolution: {integrity: sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==}
+  '@swc/helpers@0.5.23':
+    resolution: {integrity: sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==}
 
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
@@ -1282,9 +1269,6 @@ packages:
   cookie@0.7.2:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
-
-  core-js@3.47.0:
-    resolution: {integrity: sha512-c3Q2VVkGAUyupsjRnaNX6u8Dq2vAdzm9iuPj5FW0fRxzlxgq9Q39MDq10IvmQSpLgHQNyQzQmOo6bgGHmH3NNg==}
 
   core-js@3.49.0:
     resolution: {integrity: sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==}
@@ -2062,14 +2046,14 @@ packages:
     resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
     engines: {node: '>= 18'}
 
-  rsbuild-plugin-dts@0.19.2:
-    resolution: {integrity: sha512-neuTRt+H/isd2FDYMigF5TEoLUoR/hF0RKdVv1U7nDz0CfLRUfL+NnxePv9nS7dU2VvM3CYcLH7tZs43ol7g4Q==}
-    engines: {node: '>=18.12.0'}
+  rsbuild-plugin-dts@0.23.0:
+    resolution: {integrity: sha512-3dyx2+ZeIFRR1E3f28wQrcDW1kMa15thHBe97dJby/rE9GQusGPw+td8sVQnxcxhXwzy7eFkUOzN5XoZ/Nj++A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       '@microsoft/api-extractor': ^7
-      '@rsbuild/core': 1.x
-      '@typescript/native-preview': 7.x
-      typescript: ^5
+      '@rsbuild/core': ^1.0.0 || ^2.0.0-0
+      '@typescript/native-preview': ^7.0.0-0
+      typescript: ^5 || ^6
     peerDependenciesMeta:
       '@microsoft/api-extractor':
         optional: true
@@ -2231,10 +2215,6 @@ packages:
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
-
-  tinypool@1.1.1:
-    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
-    engines: {node: ^18.0.0 || >=20.0.0}
 
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
@@ -2623,18 +2603,18 @@ snapshots:
       human-id: 4.1.3
       prettier: 2.8.8
 
-  '@emnapi/core@1.8.1':
+  '@emnapi/core@1.10.0':
     dependencies:
-      '@emnapi/wasi-threads': 1.1.0
+      '@emnapi/wasi-threads': 1.2.1
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/runtime@1.8.1':
+  '@emnapi/runtime@1.10.0':
     dependencies:
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/wasi-threads@1.1.0':
+  '@emnapi/wasi-threads@1.2.1':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -2939,35 +2919,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@module-federation/error-codes@0.22.0': {}
-
-  '@module-federation/runtime-core@0.22.0':
+  '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
-      '@module-federation/error-codes': 0.22.0
-      '@module-federation/sdk': 0.22.0
-
-  '@module-federation/runtime-tools@0.22.0':
-    dependencies:
-      '@module-federation/runtime': 0.22.0
-      '@module-federation/webpack-bundler-runtime': 0.22.0
-
-  '@module-federation/runtime@0.22.0':
-    dependencies:
-      '@module-federation/error-codes': 0.22.0
-      '@module-federation/runtime-core': 0.22.0
-      '@module-federation/sdk': 0.22.0
-
-  '@module-federation/sdk@0.22.0': {}
-
-  '@module-federation/webpack-bundler-runtime@0.22.0':
-    dependencies:
-      '@module-federation/runtime': 0.22.0
-      '@module-federation/sdk': 0.22.0
-
-  '@napi-rs/wasm-runtime@1.0.7':
-    dependencies:
-      '@emnapi/core': 1.8.1
-      '@emnapi/runtime': 1.8.1
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
       '@tybys/wasm-util': 0.10.1
     optional: true
 
@@ -2987,110 +2942,117 @@ snapshots:
     dependencies:
       tinyexec: 1.2.4
 
-  '@rsbuild/core@1.7.1':
+  '@rsbuild/core@2.0.15(core-js@3.49.0)':
     dependencies:
-      '@rspack/core': 1.7.0(@swc/helpers@0.5.18)
-      '@rspack/lite-tapable': 1.1.0
-      '@swc/helpers': 0.5.18
-      core-js: 3.47.0
-      jiti: 2.6.1
+      '@rspack/core': 2.0.8(@swc/helpers@0.5.23)
+      '@swc/helpers': 0.5.23
+    optionalDependencies:
+      core-js: 3.49.0
+    transitivePeerDependencies:
+      - '@module-federation/runtime-tools'
 
-  '@rslib/core@0.19.2(@microsoft/api-extractor@7.56.2(@types/node@24.10.10))(typescript@5.9.3)':
+  '@rslib/core@0.23.0(@microsoft/api-extractor@7.56.2(@types/node@24.10.10))(core-js@3.49.0)(typescript@5.9.3)':
     dependencies:
-      '@rsbuild/core': 1.7.1
-      rsbuild-plugin-dts: 0.19.2(@microsoft/api-extractor@7.56.2(@types/node@24.10.10))(@rsbuild/core@1.7.1)(typescript@5.9.3)
+      '@rsbuild/core': 2.0.15(core-js@3.49.0)
+      rsbuild-plugin-dts: 0.23.0(@microsoft/api-extractor@7.56.2(@types/node@24.10.10))(@rsbuild/core@2.0.15(core-js@3.49.0))(typescript@5.9.3)
     optionalDependencies:
       '@microsoft/api-extractor': 7.56.2(@types/node@24.10.10)
       typescript: 5.9.3
     transitivePeerDependencies:
+      - '@module-federation/runtime-tools'
       - '@typescript/native-preview'
+      - core-js
 
-  '@rslib/core@0.19.2(@microsoft/api-extractor@7.56.2(@types/node@24.10.8))(typescript@5.9.3)':
+  '@rslib/core@0.23.0(@microsoft/api-extractor@7.56.2(@types/node@24.10.8))(core-js@3.49.0)(typescript@5.9.3)':
     dependencies:
-      '@rsbuild/core': 1.7.1
-      rsbuild-plugin-dts: 0.19.2(@microsoft/api-extractor@7.56.2(@types/node@24.10.8))(@rsbuild/core@1.7.1)(typescript@5.9.3)
+      '@rsbuild/core': 2.0.15(core-js@3.49.0)
+      rsbuild-plugin-dts: 0.23.0(@microsoft/api-extractor@7.56.2(@types/node@24.10.8))(@rsbuild/core@2.0.15(core-js@3.49.0))(typescript@5.9.3)
     optionalDependencies:
       '@microsoft/api-extractor': 7.56.2(@types/node@24.10.8)
       typescript: 5.9.3
     transitivePeerDependencies:
+      - '@module-federation/runtime-tools'
       - '@typescript/native-preview'
+      - core-js
 
-  '@rslib/core@0.19.2(@microsoft/api-extractor@7.56.2(@types/node@24.13.2))(typescript@5.9.3)':
+  '@rslib/core@0.23.0(@microsoft/api-extractor@7.56.2(@types/node@24.13.2))(core-js@3.49.0)(typescript@5.9.3)':
     dependencies:
-      '@rsbuild/core': 1.7.1
-      rsbuild-plugin-dts: 0.19.2(@microsoft/api-extractor@7.56.2(@types/node@24.13.2))(@rsbuild/core@1.7.1)(typescript@5.9.3)
+      '@rsbuild/core': 2.0.15(core-js@3.49.0)
+      rsbuild-plugin-dts: 0.23.0(@microsoft/api-extractor@7.56.2(@types/node@24.13.2))(@rsbuild/core@2.0.15(core-js@3.49.0))(typescript@5.9.3)
     optionalDependencies:
       '@microsoft/api-extractor': 7.56.2(@types/node@24.13.2)
       typescript: 5.9.3
     transitivePeerDependencies:
+      - '@module-federation/runtime-tools'
       - '@typescript/native-preview'
+      - core-js
 
-  '@rspack/binding-darwin-arm64@1.7.0':
+  '@rspack/binding-darwin-arm64@2.0.8':
     optional: true
 
-  '@rspack/binding-darwin-x64@1.7.0':
+  '@rspack/binding-darwin-x64@2.0.8':
     optional: true
 
-  '@rspack/binding-linux-arm64-gnu@1.7.0':
+  '@rspack/binding-linux-arm64-gnu@2.0.8':
     optional: true
 
-  '@rspack/binding-linux-arm64-musl@1.7.0':
+  '@rspack/binding-linux-arm64-musl@2.0.8':
     optional: true
 
-  '@rspack/binding-linux-x64-gnu@1.7.0':
+  '@rspack/binding-linux-x64-gnu@2.0.8':
     optional: true
 
-  '@rspack/binding-linux-x64-musl@1.7.0':
+  '@rspack/binding-linux-x64-musl@2.0.8':
     optional: true
 
-  '@rspack/binding-wasm32-wasi@1.7.0':
+  '@rspack/binding-wasm32-wasi@2.0.8':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.0.7
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optional: true
 
-  '@rspack/binding-win32-arm64-msvc@1.7.0':
+  '@rspack/binding-win32-arm64-msvc@2.0.8':
     optional: true
 
-  '@rspack/binding-win32-ia32-msvc@1.7.0':
+  '@rspack/binding-win32-ia32-msvc@2.0.8':
     optional: true
 
-  '@rspack/binding-win32-x64-msvc@1.7.0':
+  '@rspack/binding-win32-x64-msvc@2.0.8':
     optional: true
 
-  '@rspack/binding@1.7.0':
+  '@rspack/binding@2.0.8':
     optionalDependencies:
-      '@rspack/binding-darwin-arm64': 1.7.0
-      '@rspack/binding-darwin-x64': 1.7.0
-      '@rspack/binding-linux-arm64-gnu': 1.7.0
-      '@rspack/binding-linux-arm64-musl': 1.7.0
-      '@rspack/binding-linux-x64-gnu': 1.7.0
-      '@rspack/binding-linux-x64-musl': 1.7.0
-      '@rspack/binding-wasm32-wasi': 1.7.0
-      '@rspack/binding-win32-arm64-msvc': 1.7.0
-      '@rspack/binding-win32-ia32-msvc': 1.7.0
-      '@rspack/binding-win32-x64-msvc': 1.7.0
+      '@rspack/binding-darwin-arm64': 2.0.8
+      '@rspack/binding-darwin-x64': 2.0.8
+      '@rspack/binding-linux-arm64-gnu': 2.0.8
+      '@rspack/binding-linux-arm64-musl': 2.0.8
+      '@rspack/binding-linux-x64-gnu': 2.0.8
+      '@rspack/binding-linux-x64-musl': 2.0.8
+      '@rspack/binding-wasm32-wasi': 2.0.8
+      '@rspack/binding-win32-arm64-msvc': 2.0.8
+      '@rspack/binding-win32-ia32-msvc': 2.0.8
+      '@rspack/binding-win32-x64-msvc': 2.0.8
 
-  '@rspack/core@1.7.0(@swc/helpers@0.5.18)':
+  '@rspack/core@2.0.8(@swc/helpers@0.5.23)':
     dependencies:
-      '@module-federation/runtime-tools': 0.22.0
-      '@rspack/binding': 1.7.0
-      '@rspack/lite-tapable': 1.1.0
+      '@rspack/binding': 2.0.8
     optionalDependencies:
-      '@swc/helpers': 0.5.18
+      '@swc/helpers': 0.5.23
 
-  '@rspack/lite-tapable@1.1.0': {}
-
-  '@rstest/adapter-rslib@0.1.1(@rslib/core@0.19.2(@microsoft/api-extractor@7.56.2(@types/node@24.10.10))(typescript@5.9.3))(typescript@5.9.3)':
+  '@rstest/adapter-rslib@0.1.1(@rslib/core@0.23.0(@microsoft/api-extractor@7.56.2(@types/node@24.10.10))(core-js@3.49.0)(typescript@5.9.3))(typescript@5.9.3)':
     dependencies:
-      '@rslib/core': 0.19.2(@microsoft/api-extractor@7.56.2(@types/node@24.10.10))(typescript@5.9.3)
+      '@rslib/core': 0.23.0(@microsoft/api-extractor@7.56.2(@types/node@24.10.10))(core-js@3.49.0)(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
 
-  '@rstest/core@0.7.9':
+  '@rstest/core@0.10.6(core-js@3.49.0)':
     dependencies:
-      '@rsbuild/core': 1.7.1
+      '@rsbuild/core': 2.0.15(core-js@3.49.0)
       '@types/chai': 5.2.3
-      tinypool: 1.1.1
+    transitivePeerDependencies:
+      - '@module-federation/runtime-tools'
+      - core-js
 
   '@rushstack/node-core-library@5.19.1(@types/node@24.10.10)':
     dependencies:
@@ -3207,7 +3169,7 @@ snapshots:
       - '@types/node'
     optional: true
 
-  '@swc/helpers@0.5.18':
+  '@swc/helpers@0.5.23':
     dependencies:
       tslib: 2.8.1
 
@@ -3542,8 +3504,6 @@ snapshots:
   cookie-signature@1.2.2: {}
 
   cookie@0.7.2: {}
-
-  core-js@3.47.0: {}
 
   core-js@3.49.0: {}
 
@@ -3990,7 +3950,8 @@ snapshots:
 
   isexe@2.0.0: {}
 
-  jiti@2.6.1: {}
+  jiti@2.6.1:
+    optional: true
 
   jju@1.4.0: {}
 
@@ -4310,35 +4271,35 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  rsbuild-plugin-dts@0.19.2(@microsoft/api-extractor@7.56.2(@types/node@24.10.10))(@rsbuild/core@1.7.1)(typescript@5.9.3):
+  rsbuild-plugin-dts@0.23.0(@microsoft/api-extractor@7.56.2(@types/node@24.10.10))(@rsbuild/core@2.0.15(core-js@3.49.0))(typescript@5.9.3):
     dependencies:
       '@ast-grep/napi': 0.37.0
-      '@rsbuild/core': 1.7.1
+      '@rsbuild/core': 2.0.15(core-js@3.49.0)
     optionalDependencies:
       '@microsoft/api-extractor': 7.56.2(@types/node@24.10.10)
       typescript: 5.9.3
 
-  rsbuild-plugin-dts@0.19.2(@microsoft/api-extractor@7.56.2(@types/node@24.10.8))(@rsbuild/core@1.7.1)(typescript@5.9.3):
+  rsbuild-plugin-dts@0.23.0(@microsoft/api-extractor@7.56.2(@types/node@24.10.8))(@rsbuild/core@2.0.15(core-js@3.49.0))(typescript@5.9.3):
     dependencies:
       '@ast-grep/napi': 0.37.0
-      '@rsbuild/core': 1.7.1
+      '@rsbuild/core': 2.0.15(core-js@3.49.0)
     optionalDependencies:
       '@microsoft/api-extractor': 7.56.2(@types/node@24.10.8)
       typescript: 5.9.3
 
-  rsbuild-plugin-dts@0.19.2(@microsoft/api-extractor@7.56.2(@types/node@24.13.2))(@rsbuild/core@1.7.1)(typescript@5.9.3):
+  rsbuild-plugin-dts@0.23.0(@microsoft/api-extractor@7.56.2(@types/node@24.13.2))(@rsbuild/core@2.0.15(core-js@3.49.0))(typescript@5.9.3):
     dependencies:
       '@ast-grep/napi': 0.37.0
-      '@rsbuild/core': 1.7.1
+      '@rsbuild/core': 2.0.15(core-js@3.49.0)
     optionalDependencies:
       '@microsoft/api-extractor': 7.56.2(@types/node@24.13.2)
       typescript: 5.9.3
 
-  rsbuild-plugin-publint@1.0.0(@rsbuild/core@1.7.1):
+  rsbuild-plugin-publint@1.0.0(@rsbuild/core@2.0.15(core-js@3.49.0)):
     dependencies:
       publint: 0.3.21
     optionalDependencies:
-      '@rsbuild/core': 1.7.1
+      '@rsbuild/core': 2.0.15(core-js@3.49.0)
 
   run-parallel@1.2.0:
     dependencies:
@@ -4500,8 +4461,6 @@ snapshots:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
-
-  tinypool@1.1.1: {}
 
   to-regex-range@5.0.1:
     dependencies:


### PR DESCRIPTION
When `skipPackageJSON` is true during skill export, `package.json` is
now still copied if the package's `files` array explicitly includes it.
This allows skills using Node.js subpath imports (`#daemon-entry`) to
keep their package.json in the exported output — required for
`createRequire().resolve('#...')` to work at runtime.

The `@lynx-js/skill-lynx-devtool` package now lists `"package.json"`
in its `files` field to opt in.