### PR TITLE
fix: add npm repository metadata

### DIFF
--- a/.changeset/fix-npm-publish-metadata.md
+++ b/.changeset/fix-npm-publish-metadata.md
@@ -1,0 +1,4 @@
+---
+---
+
+Add npm repository metadata for trusted publishing provenance.

--- a/.github/instructions/changesets.instructions.md
+++ b/.github/instructions/changesets.instructions.md
@@ -1,0 +1,9 @@
+---
+applyTo: "**"
+---
+
+# Changeset Instructions
+
+- Pull requests that change publishable workspace packages must include a changeset.
+- If a package change is metadata-only or otherwise does not need a release, run `pnpm changeset add --empty` and commit the generated empty changeset file.
+- The CI changeset check runs `pnpm changeset status --since=origin/main`, so untracked changeset files do not count until they are added to git.

--- a/packages/mcp-servers/devtool-connector/package.json
+++ b/packages/mcp-servers/devtool-connector/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@lynx-js/devtool-connector",
   "version": "0.9.4",
+  "repository": {
+    "url": "https://github.com/lynx-community/skills"
+  },
   "license": "Apache-2.0",
   "type": "module",
   "imports": {

--- a/packages/mcp-servers/devtool-mcp-server/package.json
+++ b/packages/mcp-servers/devtool-mcp-server/package.json
@@ -2,6 +2,9 @@
   "name": "@lynx-js/devtool-mcp-server",
   "version": "0.13.4",
   "description": "A mcp server that lets coding agents to control, operate and preview Lynx pages.",
+  "repository": {
+    "url": "https://github.com/lynx-community/skills"
+  },
   "license": "Apache-2.0",
   "type": "module",
   "exports": {

--- a/packages/skills/lynx-devtool/package.json
+++ b/packages/skills/lynx-devtool/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@lynx-js/skill-lynx-devtool",
   "version": "0.13.4",
+  "repository": {
+    "url": "https://github.com/lynx-community/skills"
+  },
   "type": "module",
   "imports": {
     "#daemon-entry": "./scripts/daemon-entry.mjs"


### PR DESCRIPTION
## Summary
- Add matching `repository.url` metadata to the packages that were missing it during npm publish.
- Align package metadata with the GitHub repository expected by npm trusted publishing provenance.

## Validation
- `npx --yes sort-package-json@3.4.0 --check packages/mcp-servers/devtool-connector/package.json packages/mcp-servers/devtool-mcp-server/package.json packages/skills/lynx-devtool/package.json`
- Custom node metadata check for public `@lynx-js/*` packages
- `git diff --check`

## Note
The failed release also showed `ENEEDAUTH` for some packages. After this metadata fix, npmjs.com still needs Trusted Publisher entries for the packages that are published from this repo, using repository `lynx-community/skills`, workflow `release.yml`, and environment `npm`.