### PR TITLE
fix: make lynx devtool skill private

### DIFF
--- a/.changeset/fix-npm-publish-metadata.md
+++ b/.changeset/fix-npm-publish-metadata.md
@@ -1,4 +1,0 @@
----
----
-
-Add npm repository metadata for trusted publishing provenance.

--- a/packages/skills/lynx-devtool/package.json
+++ b/packages/skills/lynx-devtool/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@lynx-js/skill-lynx-devtool",
   "version": "0.13.4",
+  "private": true,
   "repository": {
     "url": "https://github.com/lynx-community/skills"
   },

--- a/packages/skills/lynx-devtool/package.json
+++ b/packages/skills/lynx-devtool/package.json
@@ -13,7 +13,6 @@
     "lynx-devtool": "./scripts/index.mjs"
   },
   "files": [
-    "package.json",
     "SKILL.md",
     "scripts",
     "public",


### PR DESCRIPTION
## Summary
- mark @lynx-js/skill-lynx-devtool as private so it is excluded from npm publishing
- remove the empty changeset that prevented the release workflow from retrying unpublished packages

## Verification
- corepack pnpm changeset status --since=origin/main
- corepack pnpm check