### PR TITLE
ci: only trigger evals-comment when skill content changes

### DIFF
--- a/.github/workflows/evals-comment.yml
+++ b/.github/workflows/evals-comment.yml
@@ -3,8 +3,20 @@ name: Evals Comment
 on:
   pull_request:
     branches: [main]
+    paths:
+      - 'packages/skills/**'
+      - 'packages/plugins/**/skills/**'
+      - 'scripts/skill-eval/**'
+      - '.github/workflows/evals-comment.yml'
+      - '.github/actions/evals-comment/**'
   push:
     branches: [main]
+    paths:
+      - 'packages/skills/**'
+      - 'packages/plugins/**/skills/**'
+      - 'scripts/skill-eval/**'
+      - '.github/workflows/evals-comment.yml'
+      - '.github/actions/evals-comment/**'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Add `paths` filters to the `evals-comment` workflow so it only runs when skill-related files are modified:

- `packages/skills/**`
- `packages/plugins/**/skills/**`
- `scripts/skill-eval/**`
- `.github/workflows/evals-comment.yml`
- `.github/actions/evals-comment/**`

`workflow_dispatch` remains unrestricted for manual triggers.