### PR TITLE
fix: keep lynx devtool package manifest in export

### DIFF
--- a/packages/skills/lynx-devtool/package.json
+++ b/packages/skills/lynx-devtool/package.json
@@ -13,6 +13,7 @@
     "lynx-devtool": "./scripts/index.mjs"
   },
   "files": [
+    "package.json",
     "SKILL.md",
     "scripts",
     "public",


### PR DESCRIPTION
## Summary

- Restore `package.json` in `@lynx-js/skill-lynx-devtool` package `files` so build-plugin keeps it during skill export.
- Keep the skill private while preserving the manifest required for `#daemon-entry` package imports.

## Root Cause

#91 made `@lynx-js/skill-lynx-devtool` private and also removed `package.json` from its `files` list. The build-plugin only copies package manifests for skills that explicitly opt in, so the release branch export still dropped `skills/lynx-devtool/package.json`.

## Validation

- `pnpm --filter build-plugin test`
- `pnpm changeset status --since=origin/main`
- `pnpm run build`
- `pnpm check`
- Verified `skills/lynx-devtool/package.json`, `scripts/daemon-entry.mjs`, and `public/inspector-wrapper.html` exist after export.
- Verified `createRequire(.../skills/lynx-devtool/scripts/index.mjs).resolve("#daemon-entry")` resolves to the exported daemon entry.
