### PR TITLE
feat: add Lynx CSS support skill

### DIFF
--- a/.changeset/fuzzy-styles-check.md
+++ b/.changeset/fuzzy-styles-check.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/skill-lynx-check-css-support": minor
+---
+
+Add a Lynx CSS support-checking skill backed by `@lynx-js/css-defines`, including a read-only dataset update check.

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ A collection of [Agent skills](https://agentskills.io/) for [Lynx](https://lynxj
 ## Available Skills
 
 - [reactlynx-best-practices](./packages/skills/reactlynx-best-practices): ReactLynx dual-thread best practices, static analysis, and auto-fixes.
+- [lynx-check-css-support](./packages/skills/lynx-check-css-support): Check Lynx CSS property and feature support by backend and Lynx version.
 - [lynx-debug-info-remapping](./packages/skills/lynx-debug-info-remapping): Remap `function_id:pc_index` runtime errors to original source positions with `debug-info.json`.
 - [lynx-devtool](./packages/skills/lynx-devtool): Inspect and debug Lynx apps through DevTool CLI, CDP/App commands, console logs, sources, and screenshots.
 - [lynx-trace-analysis](https://www.npmjs.com/package/@lynx-js/skill-lynx-trace-analysis): Analyze Lynx traces to diagnose loading, rendering, smoothness, and native module performance issues.

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@lynx-js/ai-plugin-reactlynx": "workspace:*",
     "@lynx-js/skill-habitat-usage": "workspace:*",
     "@lynx-js/skill-lynx-a2ui": "workspace:*",
+    "@lynx-js/skill-lynx-check-css-support": "workspace:*",
     "@lynx-js/skill-lynx-debug-info-remapping": "workspace:*",
     "@lynx-js/skill-lynx-devtool": "workspace:*",
     "@lynx-js/skill-lynx-trace-analysis": "0.0.6",

--- a/packages/skills/lynx-check-css-support/SKILL.md
+++ b/packages/skills/lynx-check-css-support/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: lynx-check-css-support
+description: Query @lynx-js/css-defines compat_data to check Lynx CSS property and nested feature/value support by rendering backend and Lynx version, or check whether a newer dataset version exists. Use when asked whether CSS is supported in Lynx or ReactLynx, which backends support it, when support was added, whether a style change is compatible, whether the bundled data is current, or when inspecting the raw definition JSON.
+---
+
+# Check Lynx CSS Support
+
+Use the bundled CLI instead of inferring Lynx support from browser CSS behavior, documentation examples, or TypeScript types. Its data is pinned and bundled when the skill is built, so running a query never downloads or executes packages.
+
+Treat this skill as the authority for declared backend/version availability. For questions about how a property behaves, layout semantics, syntax, or usage examples, consult the official Lynx documentation. If a request asks both whether a feature is supported and how it behaves, query support here first, then consult the docs.
+
+## Query support
+
+Resolve this skill directory, then run:
+
+```bash
+node <skill-directory>/scripts/query-css-compat.mjs <property> [options]
+```
+
+Query the property's base compatibility across every backend:
+
+```bash
+node <skill-directory>/scripts/query-css-compat.mjs display
+```
+
+Pass the user's backend and Lynx version when provided. Omitting `--backend` returns every backend. `--lynx-version` classifies availability for that target; it does not change the published `version_added` value.
+
+```bash
+node <skill-directory>/scripts/query-css-compat.mjs display \
+  --feature grid \
+  --backend android \
+  --lynx-version 2.0
+```
+
+Pass nested feature keys exactly as published. They are case-sensitive and may contain punctuation, such as `Flex`, `rotateX`, or `circle()`. If the exact key is unknown, inspect the property's `compat_data` with `--json` before querying the feature.
+
+```bash
+node <skill-directory>/scripts/query-css-compat.mjs filter \
+  --feature brightness \
+  --backend harmony \
+  --lynx-version 3.5 \
+  --json
+```
+
+## Report findings
+
+Give a concise answer containing:
+
+- The property and nested feature/value, if any.
+- The requested backend and Lynx version, or that all backends were compared.
+- The resulting `availability` and published `version_added` value or condition.
+- Any relevant notes, `partial_implementation`, deprecated, or experimental status.
+- The `@lynx-js/css-defines` version shown by the script.
+
+If a definition has no `compat_data`, report that compatibility is unspecified by the dataset. Do not interpret missing compatibility data as unsupported.
+
+Never claim backend support from the definition's top-level `version` or a value's `version` field when `compat_data.__compat.support` provides backend-specific evidence. Do not treat declared availability as proof of browser parity or complete runtime behavior.
+
+## Interpret results
+
+Treat `version_added` as follows:
+
+- A numeric version string is the minimum Lynx version for that backend.
+- A non-numeric string is a conditional requirement such as a `targetSdkVersion` gate; preserve and report it verbatim.
+- `true` means supported without a numeric minimum in the dataset.
+- `false` means unsupported.
+- `null` means unknown.
+
+Treat `availability` as follows:
+
+- `available`: supported at the requested version, or supported at some version when no target was supplied.
+- `requires-newer-version`: supported only after the requested version.
+- `conditional`: support depends on the non-numeric condition shown in `version_added` and cannot be decided from the Lynx version alone.
+- `unavailable`: explicitly unsupported.
+- `unknown`: not established by the dataset.
+
+## Keep data current
+
+Report the displayed package version with every compatibility answer. When the user asks whether the data is current, or freshness is important to the task, run:
+
+```bash
+node <skill-directory>/scripts/query-css-compat.mjs --check-updates
+```
+
+Use `--json` when structured output is useful. The check reads only the latest numeric version from the public npm registry. It does not download dataset files, modify the bundled copy, or accept cache overrides. If an update is available, report both versions and recommend updating the skill. Compatibility data changes only through reviewed skill releases that bump the pinned dependency.

--- a/packages/skills/lynx-check-css-support/agents/openai.yaml
+++ b/packages/skills/lynx-check-css-support/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Lynx CSS Support Check"
+  short_description: "Check CSS support by backend and Lynx version"
+  default_prompt: "Use $lynx-check-css-support to determine whether a Lynx CSS property or feature is supported for specified backends and Lynx versions."

--- a/packages/skills/lynx-check-css-support/build.mjs
+++ b/packages/skills/lynx-check-css-support/build.mjs
@@ -1,0 +1,24 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { copyFile, cp, mkdir, rm } from 'node:fs/promises';
+import { createRequire } from 'node:module';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const require = createRequire(import.meta.url);
+const packageJsonPath = require.resolve('@lynx-js/css-defines/package.json');
+const packageRoot = dirname(packageJsonPath);
+const targetRoot = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  'scripts/css-defines',
+);
+
+await rm(targetRoot, { recursive: true, force: true });
+await mkdir(targetRoot, { recursive: true });
+await Promise.all([
+  copyFile(packageJsonPath, resolve(targetRoot, 'package.json')),
+  cp(resolve(packageRoot, 'css_defines'), resolve(targetRoot, 'css_defines'), {
+    recursive: true,
+  }),
+]);

--- a/packages/skills/lynx-check-css-support/evals/evals.json
+++ b/packages/skills/lynx-check-css-support/evals/evals.json
@@ -1,0 +1,76 @@
+{
+  "skill_name": "lynx-check-css-support",
+  "description": "End-to-end task evals for querying @lynx-js/css-defines compatibility data, interpreting backend/version availability, and routing behavioral CSS questions to the official Lynx documentation.",
+  "evals": [
+    {
+      "id": 1,
+      "name": "android-grid-before-minimum-version",
+      "prompt": "I am targeting Lynx 2.0 on Android and want to use `display: grid`. Check the published compatibility data and tell me whether I can use it. Include the minimum supported version and the data package version you consulted.",
+      "expected_output": "A CLI-backed answer stating that display.grid requires Lynx 2.1 on Android, so it is not yet available in Lynx 2.0, together with the queried @lynx-js/css-defines version.",
+      "expectations": [
+        "The response runs or cites the bundled query for property `display`, feature `grid`, backend `android`, and Lynx version `2.0`.",
+        "The result is reported as `requires-newer-version`, not available or unsupported.",
+        "The published minimum `version_added` is reported as Lynx 2.1.",
+        "The answer mentions the @lynx-js/css-defines version shown by the script.",
+        "The answer does not use the definition-level or value-level version as backend compatibility evidence."
+      ],
+      "files": []
+    },
+    {
+      "id": 2,
+      "name": "compare-brightness-backends",
+      "prompt": "Compare the `brightness` feature of the Lynx CSS `filter` property across every rendering backend. I did not specify a target Lynx version, so give me each backend's published minimum or non-numeric support marker and identify the package version used.",
+      "expected_output": "A complete all-backend compatibility comparison for filter.brightness using the bundled CLI, preserving numeric minimum versions and boolean support markers.",
+      "expectations": [
+        "The response queries property `filter` with feature `brightness` and does not restrict the query to one backend.",
+        "Android, iOS, Harmony, and the published Clay backends are reported with `version_added` 3.6.",
+        "WebLynx is reported with the published boolean marker `true`, without inventing a numeric minimum.",
+        "The response explains that `available` without a target means supported at some version, while still reporting the minimum version values.",
+        "The answer mentions the @lynx-js/css-defines version shown by the script."
+      ],
+      "files": []
+    },
+    {
+      "id": 3,
+      "name": "support-and-semantics-routing",
+      "prompt": "For a ReactLynx page targeting Android Lynx 2.0, tell me whether `display: grid` is supported and also explain exactly how Lynx grid sizes implicit rows compared with browsers.",
+      "expected_output": "A compatibility result obtained from the bundled CLI, followed by an explicit handoff to the official Lynx documentation for behavioral grid semantics rather than inferring browser parity from compat_data.",
+      "expectations": [
+        "The support portion is answered from the bundled compatibility CLI for display.grid on Android Lynx 2.0.",
+        "The response reports `requires-newer-version` with minimum Lynx 2.1.",
+        "The response states that compat_data establishes declared availability but not complete runtime or browser behavioral parity.",
+        "The behavioral question is routed to the official Lynx documentation instead of being answered from compatibility data alone.",
+        "The answer mentions the @lynx-js/css-defines version shown by the script."
+      ],
+      "files": []
+    },
+    {
+      "id": 4,
+      "name": "report-deprecated-compatibility-status",
+      "prompt": "Check the `support_linear_orientation` compatibility feature of the Lynx CSS property `linear-direction` across backends. I also need to know whether the selected compatibility entry is deprecated or experimental, and which @lynx-js/css-defines version supplied the answer.",
+      "expected_output": "A CLI-backed compatibility answer that visibly warns that linear-direction.support_linear_orientation is deprecated, preserves its backend support data, and identifies the queried package version.",
+      "expectations": [
+        "The response queries the bundled CLI for property `linear-direction` and feature `support_linear_orientation` rather than inferring support from documentation or TypeScript types.",
+        "The selected compatibility status is reported as deprecated.",
+        "The response does not claim that the selected compatibility entry is experimental because its published experimental flag is false.",
+        "Backend availability and version_added values are preserved independently from the deprecation warning.",
+        "The answer mentions the @lynx-js/css-defines version shown by the script."
+      ],
+      "files": []
+    },
+    {
+      "id": 5,
+      "name": "check-dataset-freshness",
+      "prompt": "Check whether this skill's bundled @lynx-js/css-defines dataset is current. Do not download, install, cache, or modify any dataset files; just report the bundled and latest published versions.",
+      "expected_output": "A version-only update check using the bundled CLI's --check-updates option, reporting both versions and whether a reviewed skill update is available without changing local data.",
+      "expectations": [
+        "The response runs the bundled CLI with `--check-updates` rather than querying a CSS property.",
+        "The answer reports the bundled @lynx-js/css-defines version.",
+        "The answer reports the latest numeric version returned by the public npm registry.",
+        "The response states whether an update is available.",
+        "The response does not download, install, cache, or treat the newer dataset contents as compatibility evidence."
+      ],
+      "files": []
+    }
+  ]
+}

--- a/packages/skills/lynx-check-css-support/evals/trigger_eval.json
+++ b/packages/skills/lynx-check-css-support/evals/trigger_eval.json
@@ -1,0 +1,74 @@
+[
+  {
+    "query": "Does Lynx 2.0 on Android support `display: grid`, and what is the minimum supported Lynx version?",
+    "should_trigger": true
+  },
+  {
+    "query": "Compare `filter: brightness()` support across Android, iOS, Harmony, Clay, and WebLynx backends.",
+    "should_trigger": true
+  },
+  {
+    "query": "Check the `gap` compat_data feature named `Flex` for Harmony and tell me its version_added value.",
+    "should_trigger": true
+  },
+  {
+    "query": "Before I ship this ReactLynx style change, verify whether `transform.rotateX` is available on clay_android in Lynx 3.2.",
+    "should_trigger": true
+  },
+  {
+    "query": "Inspect the raw @lynx-js/css-defines JSON for `clip-path.circle()` and summarize its backend compatibility.",
+    "should_trigger": true
+  },
+  {
+    "query": "这个 Lynx 页面要用 `text-decoration-thickness`，请查一下 Harmony 3.4 是否支持，以及最低版本是多少。",
+    "should_trigger": true
+  },
+  {
+    "query": "Which Lynx rendering backends explicitly mark the `display.unsupported_value` compatibility feature as false or unknown?",
+    "should_trigger": true
+  },
+  {
+    "query": "The compat data mentions a targetSdkVersion condition for this CSS feature. Query it and preserve the exact condition in the answer.",
+    "should_trigger": true
+  },
+  {
+    "query": "Is the bundled @lynx-js/css-defines dataset current, or has a newer version been published? Check without installing anything.",
+    "should_trigger": true
+  },
+  {
+    "query": "How does `display: grid` place and size child nodes in Lynx? I need layout semantics, not a backend or version support check.",
+    "should_trigger": false
+  },
+  {
+    "query": "Show me the Lynx syntax and a complete usage example for `grid-template-columns` with two responsive columns.",
+    "should_trigger": false
+  },
+  {
+    "query": "Why does margin collapsing behave differently between browsers and Lynx, and how should I rewrite the layout?",
+    "should_trigger": false
+  },
+  {
+    "query": "What is the default value of `display` in Lynx, and what is the behavioral difference between `linear` and `flex`?",
+    "should_trigger": false
+  },
+  {
+    "query": "Find the Lynx API documentation for the `filter` property and explain what the `blur()` function does.",
+    "should_trigger": false
+  },
+  {
+    "query": "TypeScript says `gridTemplateColumns` is not assignable to CSSProperties in my ReactLynx component. How should I fix the types?",
+    "should_trigger": false
+  },
+  {
+    "query": "Can I use CSS subgrid in Chrome and Safari today? Please compare current browser support.",
+    "should_trigger": false
+  },
+  {
+    "query": "My Lynx grid renders with overlapping children even though the property is recognized. Help me debug the layout implementation.",
+    "should_trigger": false
+  },
+  {
+    "query": "Update every npm dependency in my repository to its latest version and fix the lockfile.",
+    "should_trigger": false
+  }
+]

--- a/packages/skills/lynx-check-css-support/package.json
+++ b/packages/skills/lynx-check-css-support/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@lynx-js/skill-lynx-check-css-support",
+  "version": "0.0.0",
+  "description": "Check Lynx CSS support by property, feature, backend, and Lynx version",
+  "repository": {
+    "url": "https://github.com/lynx-community/skills"
+  },
+  "type": "module",
+  "files": [
+    "SKILL.md",
+    "agents",
+    "scripts"
+  ],
+  "scripts": {
+    "build": "rslib build && node build.mjs",
+    "test": "pnpm typecheck && pnpm build && node --test test/*.test.mjs",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@lynx-js/css-defines": "0.0.16"
+  },
+  "devDependencies": {
+    "@rslib/core": "catalog:rstack",
+    "@types/node": "^24.10.4",
+    "commander": "^13.1.0",
+    "ky": "^1.14.3",
+    "typescript": "^5.9.3",
+    "zod": "^4.3.5"
+  },
+  "engines": {
+    "node": ">=18.17"
+  }
+}

--- a/packages/skills/lynx-check-css-support/rslib.config.ts
+++ b/packages/skills/lynx-check-css-support/rslib.config.ts
@@ -1,0 +1,29 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { defineConfig } from '@rslib/core';
+
+export default defineConfig({
+  lib: [
+    {
+      format: 'esm',
+      syntax: ['node 18'],
+      dts: false,
+      source: {
+        entry: {
+          'query-css-compat': './src/query-css-compat.ts',
+        },
+      },
+      output: {
+        filename: {
+          js: '[name].mjs',
+        },
+        distPath: './scripts',
+      },
+      autoExtension: false,
+    },
+  ],
+  output: {
+    target: 'node',
+  },
+});

--- a/packages/skills/lynx-check-css-support/src/availability.ts
+++ b/packages/skills/lynx-check-css-support/src/availability.ts
@@ -1,0 +1,72 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import {
+  type CompatStatement,
+  type NumericVersion,
+  NumericVersionSchema,
+} from './schemas.js';
+import { compareNumericVersions } from './version.js';
+
+const AVAILABILITY = {
+  available: 'available',
+  unavailable: 'unavailable',
+  unknown: 'unknown',
+  conditional: 'conditional',
+  requiresNewerVersion: 'requires-newer-version',
+} as const;
+
+type Availability = (typeof AVAILABILITY)[keyof typeof AVAILABILITY];
+
+export type CompatibilityRow = {
+  readonly backend: string;
+  readonly version_added: string | boolean | null;
+  readonly availability: Availability;
+  readonly notes?: string | readonly string[];
+  readonly partial_implementation?: boolean;
+};
+
+function assessAvailability(
+  versionAdded: string | boolean | null,
+  targetVersion: NumericVersion | undefined,
+): Availability {
+  if (versionAdded === false) {
+    return AVAILABILITY.unavailable;
+  }
+  if (versionAdded === null) {
+    return AVAILABILITY.unknown;
+  }
+  if (versionAdded === true) {
+    return AVAILABILITY.available;
+  }
+  const parsedVersion = NumericVersionSchema.safeParse(versionAdded);
+  if (!parsedVersion.success) {
+    return AVAILABILITY.conditional;
+  }
+  if (targetVersion === undefined) {
+    return AVAILABILITY.available;
+  }
+  return compareNumericVersions(targetVersion, parsedVersion.data) >= 0
+    ? AVAILABILITY.available
+    : AVAILABILITY.requiresNewerVersion;
+}
+
+export function createCompatibilityRows(
+  statement: CompatStatement,
+  targetVersion: NumericVersion | undefined,
+  backend: string | undefined,
+): readonly CompatibilityRow[] {
+  return Object.entries(statement.support)
+    .filter(([name]) => backend === undefined || name === backend)
+    .map(([name, support]) => ({
+      backend: name,
+      version_added: support.version_added,
+      availability: assessAvailability(support.version_added, targetVersion),
+      ...(support.notes === undefined || support.notes === ''
+        ? {}
+        : { notes: support.notes }),
+      ...(support.partial_implementation === undefined
+        ? {}
+        : { partial_implementation: support.partial_implementation }),
+    }));
+}

--- a/packages/skills/lynx-check-css-support/src/data.ts
+++ b/packages/skills/lynx-check-css-support/src/data.ts
@@ -1,0 +1,194 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { readdir, readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type { CompatibilityRow } from './availability.js';
+import { createCompatibilityRows } from './availability.js';
+import {
+  BackendNameSchema,
+  type CompatStatement,
+  CssDefinesPackageSchema,
+  CssPropertyNameSchema,
+  type Definition,
+  DefinitionSchema,
+  FeatureNameSchema,
+  type NumericVersion,
+  NumericVersionSchema,
+} from './schemas.js';
+
+type PackageSource = {
+  readonly root: string;
+  readonly version: NumericVersion;
+};
+
+export type QueryOptions = {
+  readonly backend?: string;
+  readonly feature?: string;
+  readonly lynxVersion?: string;
+};
+
+export type QueryResult = {
+  readonly package: {
+    readonly name: '@lynx-js/css-defines';
+    readonly version: NumericVersion;
+    readonly source: 'bundled';
+  };
+  readonly property: Definition;
+  readonly feature: string;
+  readonly status?: NonNullable<CompatStatement['status']>;
+  readonly lynx_version?: NumericVersion;
+  readonly compatibility: readonly CompatibilityRow[] | null;
+};
+
+export class QueryError extends Error {
+  override readonly name = 'QueryError';
+  readonly exitCode = 2;
+}
+
+async function readPackageSource(root: string): Promise<PackageSource> {
+  const raw = await readFile(resolve(root, 'package.json'), 'utf8');
+  const metadata = CssDefinesPackageSchema.parse(JSON.parse(raw));
+  return { root, version: metadata.version };
+}
+
+function getBundledPackageRoot(): string {
+  return fileURLToPath(new URL('./css-defines', import.meta.url));
+}
+
+export async function getBundledPackageVersion(): Promise<NumericVersion> {
+  return (await readPackageSource(getBundledPackageRoot())).version;
+}
+
+async function readDefinition(
+  source: PackageSource,
+  propertyInput: string,
+): Promise<Definition> {
+  const property = CssPropertyNameSchema.parse(propertyInput);
+  const filenames = await readdir(resolve(source.root, 'css_defines'));
+  const filename = filenames.find((candidate) => {
+    const separator = candidate.indexOf('-');
+    if (separator < 0) {
+      return false;
+    }
+    const definitionName = candidate.slice(separator + 1, -'.json'.length);
+    return (
+      definitionName === property ||
+      (property.startsWith('-') && definitionName === property.slice(1))
+    );
+  });
+
+  if (filename === undefined) {
+    throw new QueryError(`Unknown CSS property: ${property}`);
+  }
+
+  const raw = await readFile(
+    resolve(source.root, 'css_defines', filename),
+    'utf8',
+  );
+  const definition = DefinitionSchema.parse(JSON.parse(raw));
+  if (definition.name !== property) {
+    throw new QueryError(`Unknown CSS property: ${property}`);
+  }
+  return definition;
+}
+
+async function readBundledDefinition(propertyInput: string): Promise<{
+  readonly definition: Definition;
+  readonly source: PackageSource;
+}> {
+  const source = await readPackageSource(getBundledPackageRoot());
+  return {
+    definition: await readDefinition(source, propertyInput),
+    source,
+  };
+}
+
+function selectCompatStatement(
+  definition: Definition,
+  featureInput: string | undefined,
+): { readonly feature: string; readonly statement: CompatStatement } | null {
+  if (definition.compat_data === null || definition.compat_data === undefined) {
+    if (featureInput !== undefined) {
+      const feature = FeatureNameSchema.parse(featureInput);
+      throw new QueryError(
+        `Unknown feature ${definition.name}.${feature}. Available features: none`,
+      );
+    }
+    return null;
+  }
+
+  const propertyCompat = definition.compat_data[definition.name];
+  if (propertyCompat === undefined) {
+    throw new QueryError(`Missing compatibility entry for ${definition.name}`);
+  }
+
+  if (featureInput === undefined) {
+    const base = propertyCompat['__compat'];
+    if (base === undefined || !('support' in base)) {
+      throw new QueryError(
+        `Missing base compatibility data for ${definition.name}`,
+      );
+    }
+    return { feature: definition.name, statement: base };
+  }
+
+  const feature = FeatureNameSchema.parse(featureInput);
+  const selected = propertyCompat[feature];
+  if (selected === undefined || !('__compat' in selected)) {
+    const available = Object.keys(propertyCompat)
+      .filter((name) => name !== '__compat')
+      .join(', ');
+    throw new QueryError(
+      `Unknown feature ${definition.name}.${feature}. Available features: ${available || 'none'}`,
+    );
+  }
+  return { feature, statement: selected.__compat };
+}
+
+export async function queryCompatibility(
+  propertyInput: string,
+  options: QueryOptions,
+): Promise<QueryResult> {
+  const { definition, source } = await readBundledDefinition(propertyInput);
+  const selected = selectCompatStatement(definition, options.feature);
+  const targetVersion =
+    options.lynxVersion === undefined
+      ? undefined
+      : NumericVersionSchema.parse(options.lynxVersion);
+  const backend =
+    options.backend === undefined
+      ? undefined
+      : BackendNameSchema.parse(options.backend);
+
+  if (
+    selected !== null &&
+    backend !== undefined &&
+    !Object.hasOwn(selected.statement.support, backend)
+  ) {
+    throw new QueryError(
+      `Unknown backend: ${backend}. Available backends: ${Object.keys(selected.statement.support).join(', ')}`,
+    );
+  }
+
+  const compatibility =
+    selected === null
+      ? null
+      : createCompatibilityRows(selected.statement, targetVersion, backend);
+
+  return {
+    package: {
+      name: '@lynx-js/css-defines',
+      version: source.version,
+      source: 'bundled',
+    },
+    property: definition,
+    feature: selected?.feature ?? definition.name,
+    ...(selected?.statement.status === undefined
+      ? {}
+      : { status: selected.statement.status }),
+    ...(targetVersion === undefined ? {} : { lynx_version: targetVersion }),
+    compatibility,
+  };
+}

--- a/packages/skills/lynx-check-css-support/src/query-css-compat.ts
+++ b/packages/skills/lynx-check-css-support/src/query-css-compat.ts
@@ -1,0 +1,241 @@
+#!/usr/bin/env node
+
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { Command } from 'commander';
+import { z } from 'zod';
+import {
+  getBundledPackageVersion,
+  QueryError,
+  type QueryResult,
+  queryCompatibility,
+} from './data.js';
+import { CssPropertyNameSchema } from './schemas.js';
+import {
+  checkForUpdates,
+  UpdateCheckError,
+  type UpdateCheckResult,
+} from './updates.js';
+
+type CliOptions = {
+  readonly backend?: string;
+  readonly checkUpdates?: boolean;
+  readonly feature?: string;
+  readonly json?: boolean;
+  readonly lynxVersion?: string;
+};
+
+type NormalizedArguments = {
+  readonly argv: readonly string[];
+  readonly leadingHyphenProperty?: string;
+};
+
+function formatVersionAdded(value: string | boolean | null): string {
+  if (value === null) {
+    return 'unknown';
+  }
+  return typeof value === 'boolean' ? String(value) : value;
+}
+
+function printHumanResult(result: QueryResult): void {
+  const property = result.property;
+  console.log(
+    `Package: ${result.package.name}@${result.package.version} (${result.package.source})`,
+  );
+  console.log(`Property: ${property.name} (#${property.id})`);
+  console.log(`Type: ${property.type}`);
+  console.log(`Default: ${property.default_value}`);
+  console.log(`Definition version: ${property.version}`);
+  console.log(`Description: ${property.desc}`);
+  if (property.formal_syntax !== undefined) {
+    console.log(`Syntax: ${property.formal_syntax}`);
+  }
+  if (property.values !== undefined) {
+    console.log(
+      `Values: ${property.values.map((item) => item.value).join(', ')}`,
+    );
+  }
+  console.log(`Feature: ${result.feature}`);
+
+  const statusLabels = [
+    ...(result.status?.deprecated === true ? ['deprecated'] : []),
+    ...(result.status?.experimental === true ? ['experimental'] : []),
+  ];
+  if (statusLabels.length > 0) {
+    console.log(`Status: ${statusLabels.join(', ')}`);
+  }
+
+  if (result.compatibility === null) {
+    console.log('Compatibility: no compat_data is defined for this property.');
+    return;
+  }
+
+  console.log('Compatibility:');
+  for (const row of result.compatibility) {
+    const noteText = Array.isArray(row.notes)
+      ? row.notes.join(' | ')
+      : row.notes;
+    const notes = noteText === undefined ? '' : `; notes=${noteText}`;
+    const partial = row.partial_implementation === true ? '; partial' : '';
+    console.log(
+      `- ${row.backend}: added=${formatVersionAdded(row.version_added)}; ${row.availability}${partial}${notes}`,
+    );
+  }
+}
+
+function printUpdateCheck(result: UpdateCheckResult): void {
+  if (result.update_available) {
+    console.log(
+      `Update available: ${result.package} ${result.bundled_version} -> ${result.latest_version}`,
+    );
+    return;
+  }
+  if (result.bundled_version === result.latest_version) {
+    console.log(`Up to date: ${result.package}@${result.bundled_version}`);
+    return;
+  }
+  console.log(
+    `No update available: bundled=${result.bundled_version}; registry=${result.latest_version}`,
+  );
+}
+
+function normalizeArguments(argv: readonly string[]): NormalizedArguments {
+  const valueOptions = new Set(['--backend', '--feature', '--lynx-version']);
+  let propertyIndex = -1;
+  for (let index = 2; index < argv.length; index += 1) {
+    const argument = argv[index];
+    if (argument === undefined) {
+      continue;
+    }
+    if (valueOptions.has(argument)) {
+      index += 1;
+      continue;
+    }
+    if (
+      argument.startsWith('-') &&
+      !argument.startsWith('--') &&
+      argument !== '-h' &&
+      CssPropertyNameSchema.safeParse(argument).success
+    ) {
+      propertyIndex = index;
+      break;
+    }
+  }
+  if (propertyIndex < 0) {
+    return { argv: [...argv] };
+  }
+
+  const normalized = [...argv];
+  const property = normalized[propertyIndex];
+  if (property === undefined) {
+    return { argv: normalized };
+  }
+  normalized[propertyIndex] = 'leading-hyphen-property';
+  return { argv: normalized, leadingHyphenProperty: property };
+}
+
+async function runQuery(property: string, options: CliOptions): Promise<void> {
+  const result = await queryCompatibility(property, {
+    ...(options.backend === undefined ? {} : { backend: options.backend }),
+    ...(options.feature === undefined ? {} : { feature: options.feature }),
+    ...(options.lynxVersion === undefined
+      ? {}
+      : { lynxVersion: options.lynxVersion }),
+  });
+
+  if (options.json === true) {
+    console.log(JSON.stringify(result, null, 2));
+  } else {
+    printHumanResult(result);
+  }
+}
+
+async function runUpdateCheck(json: boolean): Promise<void> {
+  const result = await checkForUpdates(await getBundledPackageVersion());
+  if (json) {
+    console.log(JSON.stringify(result, null, 2));
+    return;
+  }
+  printUpdateCheck(result);
+}
+
+async function main(): Promise<void> {
+  const normalized = normalizeArguments(process.argv);
+
+  const program = new Command()
+    .name('query-css-compat')
+    .description(
+      'Query @lynx-js/css-defines compatibility or check for a newer dataset version.',
+    )
+    .argument('[property]', 'CSS property name, for example display')
+    .option(
+      '--feature <feature>',
+      'nested compat_data feature, for example grid',
+    )
+    .option(
+      '--backend <backend>',
+      'backend such as android, ios, harmony, or web_lynx',
+    )
+    .option('--lynx-version <version>', 'target Lynx version, for example 3.4')
+    .option(
+      '--check-updates',
+      'check the latest dataset version without downloading it',
+    )
+    .option('--json', 'print the command result as JSON')
+    .showHelpAfterError();
+
+  program.action(async (property: string | undefined) => {
+    const options = program.opts<CliOptions>();
+    if (options.checkUpdates === true) {
+      if (
+        property !== undefined ||
+        options.backend !== undefined ||
+        options.feature !== undefined ||
+        options.lynxVersion !== undefined
+      ) {
+        program.error(
+          '--check-updates cannot be combined with a property or query filters',
+        );
+      }
+      await runUpdateCheck(options.json === true);
+      return;
+    }
+    if (property === undefined) {
+      program.error("error: missing required argument 'property'");
+      return;
+    }
+    await runQuery(normalized.leadingHyphenProperty ?? property, options);
+  });
+  await program.parseAsync(normalized.argv);
+}
+
+main().catch((error: unknown) => {
+  if (error instanceof UpdateCheckError) {
+    console.error(error.message);
+    process.exitCode = error.exitCode;
+    return;
+  }
+  if (error instanceof QueryError) {
+    console.error(error.message);
+    process.exitCode = error.exitCode;
+    return;
+  }
+  if (error instanceof z.ZodError) {
+    console.error(
+      error.issues
+        .map((issue) => {
+          const path = issue.path.join('.');
+          if (issue.code === 'unrecognized_keys') {
+            const prefix = path === '' ? '' : `${path}: `;
+            return `${prefix}unrecognized keys: ${issue.keys.join(', ')}`;
+          }
+          return path === '' ? issue.message : `${path}: ${issue.message}`;
+        })
+        .join('\n'),
+    );
+    process.exitCode = 2;
+    return;
+  }
+  throw error;
+});

--- a/packages/skills/lynx-check-css-support/src/schemas.ts
+++ b/packages/skills/lynx-check-css-support/src/schemas.ts
@@ -1,0 +1,118 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { z } from 'zod';
+
+export const NumericVersionSchema = z
+  .string()
+  .regex(/^\d+(?:\.\d+){0,2}$/, 'expected a numeric version such as 3.4');
+
+export const CssPropertyNameSchema = z
+  .string()
+  .regex(/^-?[a-z][a-z0-9-]*$/, 'expected a CSS property name');
+
+export const FeatureNameSchema = z
+  .string()
+  .min(1, 'expected a compatibility feature name')
+  .max(128, 'compatibility feature name is too long');
+
+export const BackendNameSchema = z
+  .string()
+  .regex(/^[a-z][a-z0-9_]*$/, 'expected a backend name');
+
+export const SupportStatementSchema = z
+  .object({
+    version_added: z.union([z.string().min(1), z.boolean(), z.null()]),
+    notes: z.union([z.string(), z.array(z.string()).readonly()]).optional(),
+    partial_implementation: z.boolean().optional(),
+  })
+  .strict()
+  .readonly();
+
+export const CompatStatementSchema = z
+  .object({
+    description: z.string().optional(),
+    lynx_path: z.string().optional(),
+    mdn_url: z.string().url().optional(),
+    spec_url: z
+      .union([z.string().url(), z.array(z.string().url()).readonly()])
+      .optional(),
+    status: z
+      .object({
+        deprecated: z.boolean(),
+        experimental: z.boolean(),
+      })
+      .strict()
+      .readonly()
+      .optional(),
+    support: z.record(BackendNameSchema, SupportStatementSchema).readonly(),
+  })
+  .strict()
+  .readonly();
+
+type FeatureCompat = {
+  readonly __compat: CompatStatement;
+  readonly [name: string]: CompatStatement | FeatureCompat;
+};
+
+const FeatureCompatSchema: z.ZodType<FeatureCompat> = z.lazy(() =>
+  z
+    .object({
+      __compat: CompatStatementSchema,
+    })
+    .catchall(FeatureCompatSchema)
+    .readonly(),
+);
+
+const CompatDataSchema = z
+  .record(CssPropertyNameSchema, FeatureCompatSchema)
+  .readonly();
+
+const PropertyValueSchema = z
+  .object({
+    value: z.string(),
+    version: NumericVersionSchema,
+    desc: z.string(),
+    'align-type': z.string().optional(),
+  })
+  .strict()
+  .readonly();
+
+const PropertyNoteSchema = z
+  .object({
+    literal: z.string(),
+    level: z.string(),
+  })
+  .strict()
+  .readonly();
+
+export const DefinitionSchema = z
+  .object({
+    name: CssPropertyNameSchema,
+    id: z.number().int().positive(),
+    type: z.string().min(1),
+    default_value: z.string(),
+    version: NumericVersionSchema,
+    author: z.string(),
+    consumption_status: z.string().min(1),
+    desc: z.string(),
+    compat_data: CompatDataSchema.nullish(),
+    formal_syntax: z.string().optional(),
+    is_shorthand: z.boolean(),
+    keywords: z.array(z.string()).readonly().optional(),
+    note: z.array(PropertyNoteSchema).readonly().optional(),
+    values: z.array(PropertyValueSchema).readonly().optional(),
+  })
+  .strict()
+  .readonly();
+
+export const CssDefinesPackageSchema = z
+  .object({
+    name: z.literal('@lynx-js/css-defines'),
+    version: NumericVersionSchema,
+  })
+  .readonly();
+
+export type CompatStatement = z.infer<typeof CompatStatementSchema>;
+export type Definition = z.infer<typeof DefinitionSchema>;
+export type NumericVersion = z.infer<typeof NumericVersionSchema>;

--- a/packages/skills/lynx-check-css-support/src/updates.ts
+++ b/packages/skills/lynx-check-css-support/src/updates.ts
@@ -1,0 +1,74 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import ky from 'ky';
+import { z } from 'zod';
+import { type NumericVersion, NumericVersionSchema } from './schemas.js';
+import { compareNumericVersions } from './version.js';
+
+const LATEST_PACKAGE_URL =
+  'https://registry.npmjs.org/@lynx-js%2Fcss-defines/latest';
+const MAX_RESPONSE_BYTES = 64 * 1024;
+
+const LatestPackageMetadataSchema = z
+  .object({
+    version: NumericVersionSchema,
+  })
+  .readonly();
+
+export type UpdateCheckResult = {
+  readonly package: '@lynx-js/css-defines';
+  readonly bundled_version: NumericVersion;
+  readonly latest_version: NumericVersion;
+  readonly update_available: boolean;
+};
+
+class RegistryResponseTooLargeError extends Error {
+  override readonly name = 'RegistryResponseTooLargeError';
+}
+
+export class UpdateCheckError extends Error {
+  override readonly name = 'UpdateCheckError';
+  readonly exitCode = 1;
+
+  constructor(cause: Error) {
+    super('Unable to check for css-defines updates.', { cause });
+  }
+}
+
+export async function checkForUpdates(
+  bundledVersion: NumericVersion,
+): Promise<UpdateCheckResult> {
+  try {
+    const metadata = LatestPackageMetadataSchema.parse(
+      await ky
+        .get(LATEST_PACKAGE_URL, {
+          cache: 'no-store',
+          credentials: 'omit',
+          headers: { accept: 'application/json' },
+          redirect: 'error',
+          referrerPolicy: 'no-referrer',
+          retry: 0,
+          timeout: 5_000,
+          onDownloadProgress(progress) {
+            if (progress.transferredBytes > MAX_RESPONSE_BYTES) {
+              throw new RegistryResponseTooLargeError();
+            }
+          },
+        })
+        .json<unknown>(),
+    );
+    return {
+      package: '@lynx-js/css-defines',
+      bundled_version: bundledVersion,
+      latest_version: metadata.version,
+      update_available:
+        compareNumericVersions(metadata.version, bundledVersion) > 0,
+    };
+  } catch (error) {
+    if (error instanceof Error) {
+      throw new UpdateCheckError(error);
+    }
+    throw error;
+  }
+}

--- a/packages/skills/lynx-check-css-support/src/version.ts
+++ b/packages/skills/lynx-check-css-support/src/version.ts
@@ -1,0 +1,21 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { type NumericVersion, NumericVersionSchema } from './schemas.js';
+
+export function compareNumericVersions(
+  left: NumericVersion,
+  right: NumericVersion,
+): number {
+  const leftParts = NumericVersionSchema.parse(left).split('.').map(Number);
+  const rightParts = NumericVersionSchema.parse(right).split('.').map(Number);
+
+  for (let index = 0; index < 3; index += 1) {
+    const difference = (leftParts[index] ?? 0) - (rightParts[index] ?? 0);
+    if (difference !== 0) {
+      return difference;
+    }
+  }
+
+  return 0;
+}

--- a/packages/skills/lynx-check-css-support/test/check-updates.test.mjs
+++ b/packages/skills/lynx-check-css-support/test/check-updates.test.mjs
@@ -1,0 +1,213 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+import { pathToFileURL } from 'node:url';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+const cliPath = new URL('../scripts/query-css-compat.mjs', import.meta.url);
+
+async function runWithPreload(t, preloadSource, ...args) {
+  const root = await mkdtemp(join(tmpdir(), 'lynx-css-update-check-'));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const preloadPath = join(root, 'mock-fetch.mjs');
+  await writeFile(preloadPath, preloadSource);
+  return execFileAsync(process.execPath, [cliPath.pathname, ...args], {
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      NODE_OPTIONS: `--import=${pathToFileURL(preloadPath).href}`,
+    },
+  });
+}
+
+async function runWithFetch(t, fetchBody, ...args) {
+  return runWithPreload(
+    t,
+    `globalThis.fetch = async () => new Response(${JSON.stringify(fetchBody)}, { headers: { 'content-type': 'application/json' } });\n`,
+    ...args,
+  );
+}
+
+test('reports a newer dataset version without exposing registry metadata', async (t) => {
+  // Given: the registry reports a newer numeric version plus untrusted text.
+  const metadata = JSON.stringify({
+    version: '0.0.17',
+    description: 'untrusted registry narrative',
+  });
+
+  // When: the standalone update check is requested as JSON.
+  const { stdout, stderr } = await runWithFetch(
+    t,
+    metadata,
+    '--check-updates',
+    '--json',
+  );
+
+  // Then: only validated version data is reported and nothing is changed.
+  assert.equal(stderr, '');
+  assert.deepEqual(JSON.parse(stdout), {
+    package: '@lynx-js/css-defines',
+    bundled_version: '0.0.16',
+    latest_version: '0.0.17',
+    update_available: true,
+  });
+  assert.doesNotMatch(stdout, /untrusted registry narrative/);
+});
+
+test('reports when the bundled dataset is current', async (t) => {
+  // Given: the registry version matches the bundled dataset.
+  const metadata = JSON.stringify({ version: '0.0.16' });
+
+  // When: the standalone update check uses human-readable output.
+  const { stdout, stderr } = await runWithFetch(t, metadata, '--check-updates');
+
+  // Then: the CLI reports that no skill release update is needed.
+  assert.equal(stderr, '');
+  assert.equal(stdout, 'Up to date: @lynx-js/css-defines@0.0.16\n');
+});
+
+test('reports when the registry version is older than the bundle', async (t) => {
+  // Given: the registry reports a numeric version older than the bundle.
+  const metadata = JSON.stringify({ version: '0.0.15' });
+
+  // When: the standalone update check uses human-readable output.
+  const { stdout, stderr } = await runWithFetch(t, metadata, '--check-updates');
+
+  // Then: the distinct no-update branch reports both versions.
+  assert.equal(stderr, '');
+  assert.equal(
+    stdout,
+    'No update available: bundled=0.0.16; registry=0.0.15\n',
+  );
+});
+
+test('fails closed when registry metadata has an invalid version', async (t) => {
+  // Given: the registry response does not contain a numeric package version.
+  const metadata = JSON.stringify({
+    version: 'latest',
+    description: 'must not be echoed',
+  });
+
+  // When: the update check parses that response.
+  await assert.rejects(
+    runWithFetch(t, metadata, '--check-updates'),
+    (error) => {
+      assert(error instanceof Error);
+
+      // Then: the command fails without exposing arbitrary registry content.
+      assert.equal(error.code, 1);
+      assert.match(error.stderr, /Unable to check for css-defines updates/);
+      assert.doesNotMatch(error.stderr, /must not be echoed/);
+      return true;
+    },
+  );
+});
+
+test('rejects oversized registry metadata', async (t) => {
+  // Given: the registry response exceeds the update check's metadata limit.
+  const metadata = JSON.stringify({
+    version: '0.0.17',
+    padding: 'x'.repeat(65 * 1024),
+  });
+
+  // When: the update check receives that response.
+  await assert.rejects(
+    runWithFetch(t, metadata, '--check-updates'),
+    (error) => {
+      assert(error instanceof Error);
+
+      // Then: the command fails without processing or echoing the payload.
+      assert.equal(error.code, 1);
+      assert.match(error.stderr, /Unable to check for css-defines updates/);
+      assert.doesNotMatch(error.stderr, /xxxx/);
+      return true;
+    },
+  );
+});
+
+test('fails closed when the registry request fails', async (t) => {
+  // Given: the network boundary rejects the registry request.
+  const preloadSource =
+    "globalThis.fetch = async () => { throw new TypeError('network unavailable'); };\n";
+
+  // When: the update check cannot fetch metadata.
+  await assert.rejects(
+    runWithPreload(t, preloadSource, '--check-updates'),
+    (error) => {
+      assert(error instanceof Error);
+
+      // Then: the CLI returns its generic failure contract on stderr only.
+      assert.equal(error.code, 1);
+      assert.equal(error.stdout, '');
+      assert.match(error.stderr, /Unable to check for css-defines updates/);
+      assert.doesNotMatch(error.stderr, /network unavailable/);
+      return true;
+    },
+  );
+});
+
+test('keeps the update check separate from compatibility queries', async (t) => {
+  // Given: a property is supplied with the standalone update-check flag.
+  const metadata = JSON.stringify({ version: '0.0.17' });
+
+  // When: the incompatible modes are requested together.
+  await assert.rejects(
+    runWithFetch(t, metadata, 'display', '--check-updates'),
+    (error) => {
+      assert(error instanceof Error);
+
+      // Then: Commander rejects the combination before querying either source.
+      assert.equal(error.code, 1);
+      assert.match(error.stderr, /cannot be combined/);
+      return true;
+    },
+  );
+});
+
+test('rejects every compatibility filter in update-check mode', async (t) => {
+  // Given: each compatibility-only filter is combined with update-check mode.
+  const metadata = JSON.stringify({ version: '0.0.17' });
+  const filters = [
+    ['--backend', 'ios'],
+    ['--feature', 'grid'],
+    ['--lynx-version', '3.4'],
+  ];
+
+  // When: each incompatible filter is requested without a property.
+  for (const filter of filters) {
+    await assert.rejects(
+      runWithFetch(t, metadata, '--check-updates', ...filter),
+      (error) => {
+        assert(error instanceof Error);
+
+        // Then: Commander rejects every combination before fetching metadata.
+        assert.equal(error.code, 1);
+        assert.match(error.stderr, /cannot be combined/);
+        return true;
+      },
+    );
+  }
+});
+
+test('still requires a property for compatibility queries', async () => {
+  // Given: neither a property nor the standalone update-check flag is supplied.
+  // When: the CLI is invoked without arguments.
+  await assert.rejects(
+    execFileAsync(process.execPath, [cliPath.pathname], { encoding: 'utf8' }),
+    (error) => {
+      assert(error instanceof Error);
+
+      // Then: the original required-property contract remains visible.
+      assert.equal(error.code, 1);
+      assert.match(error.stderr, /missing required argument 'property'/);
+      return true;
+    },
+  );
+});

--- a/packages/skills/lynx-check-css-support/test/compatibility-status.test.mjs
+++ b/packages/skills/lynx-check-css-support/test/compatibility-status.test.mjs
@@ -1,0 +1,48 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
+import test from 'node:test';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+const cliPath = new URL('../scripts/query-css-compat.mjs', import.meta.url);
+const deprecatedProperty = 'linear-direction';
+const deprecatedFeature = 'support_linear_orientation';
+
+test('returns the selected compatibility status in JSON', async () => {
+  // Given: the published base compatibility entry is deprecated.
+  // When: the property is queried as JSON.
+  const { stdout } = await execFileAsync(
+    process.execPath,
+    [
+      cliPath.pathname,
+      deprecatedProperty,
+      '--feature',
+      deprecatedFeature,
+      '--json',
+    ],
+    { encoding: 'utf8' },
+  );
+  const result = JSON.parse(stdout);
+
+  // Then: consumers can report the selected entry's status directly.
+  assert.deepEqual(result.status, {
+    deprecated: true,
+    experimental: false,
+  });
+});
+
+test('prints a deprecated warning in human-readable output', async () => {
+  // Given: the published base compatibility entry is deprecated.
+  // When: the property is queried in the default human-readable format.
+  const { stdout } = await execFileAsync(
+    process.execPath,
+    [cliPath.pathname, deprecatedProperty, '--feature', deprecatedFeature],
+    { encoding: 'utf8' },
+  );
+
+  // Then: the warning is visible without requiring a second JSON query.
+  assert.match(stdout, /^Status: deprecated$/m);
+});

--- a/packages/skills/lynx-check-css-support/test/query-css-compat.test.mjs
+++ b/packages/skills/lynx-check-css-support/test/query-css-compat.test.mjs
@@ -1,0 +1,307 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
+import test from 'node:test';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+const cliPath = new URL('../scripts/query-css-compat.mjs', import.meta.url);
+
+async function query(...args) {
+  const { stdout } = await execFileAsync(
+    process.execPath,
+    [cliPath.pathname, ...args, '--json'],
+    { encoding: 'utf8' },
+  );
+  return JSON.parse(stdout);
+}
+
+test('reports a feature as requiring a newer Lynx version', async () => {
+  // Given: display.grid was added to Android in Lynx 2.1.
+  // When: compatibility is queried for Android on Lynx 2.0.
+  const result = await query(
+    'display',
+    '--feature',
+    'grid',
+    '--backend',
+    'android',
+    '--lynx-version',
+    '2.0',
+  );
+
+  // Then: the result preserves the introduction version and rejects 2.0.
+  assert.deepEqual(result.package, {
+    name: '@lynx-js/css-defines',
+    version: '0.0.16',
+    source: 'bundled',
+  });
+  assert.equal(result.property.name, 'display');
+  assert.equal(result.feature, 'grid');
+  assert.deepEqual(result.compatibility, [
+    {
+      backend: 'android',
+      version_added: '2.1',
+      availability: 'requires-newer-version',
+    },
+  ]);
+});
+
+test('reports a feature as available at its introduction version', async () => {
+  // Given: display.grid was added to Android in Lynx 2.1.
+  // When: compatibility is queried for Android on Lynx 2.1.
+  const result = await query(
+    'display',
+    '--feature',
+    'grid',
+    '--backend',
+    'android',
+    '--lynx-version',
+    '2.1',
+  );
+
+  // Then: the feature is available.
+  assert.equal(result.compatibility[0].availability, 'available');
+});
+
+test('returns definition data when compat_data is null', async () => {
+  // Given: the content definition has no compatibility data.
+  // When: the property is queried.
+  const result = await query('content');
+
+  // Then: definition data remains available and compatibility is explicit.
+  assert.equal(result.property.name, 'content');
+  assert.equal(result.property.type, 'string');
+  assert.equal(result.compatibility, null);
+});
+
+test('rejects a feature query when compat_data is null', async () => {
+  // Given: the content definition has no compatibility data.
+  // When: a nested feature is requested for that property.
+  await assert.rejects(
+    execFileAsync(
+      process.execPath,
+      [cliPath.pathname, 'content', '--feature', 'definitely-not-real'],
+      { encoding: 'utf8' },
+    ),
+    (error) => {
+      assert(error instanceof Error);
+
+      // Then: the CLI rejects the unverified feature instead of answering for content.
+      assert.equal(error.code, 2);
+      assert.match(
+        error.stderr,
+        /Unknown feature content\.definitely-not-real/,
+      );
+      return true;
+    },
+  );
+});
+
+test('rejects an unknown CSS property', async () => {
+  // Given: a property absent from css-defines.
+  // When: it is queried through the CLI.
+  try {
+    await execFileAsync(
+      process.execPath,
+      [cliPath.pathname, 'definitely-not-a-property'],
+      { encoding: 'utf8' },
+    );
+    assert.fail('Expected the CLI to reject an unknown property');
+  } catch (error) {
+    assert(error instanceof Error);
+
+    // Then: the CLI exits non-zero with an actionable error.
+    assert.equal(error.code, 2);
+    assert.match(error.stderr, /Unknown CSS property/);
+  }
+});
+
+test('rejects inherited object properties as backend names', async () => {
+  // Given: constructor exists on Object.prototype but is not a backend.
+  // When: it is passed through the backend option.
+  await assert.rejects(
+    execFileAsync(
+      process.execPath,
+      [cliPath.pathname, 'display', '--backend', 'constructor'],
+      { encoding: 'utf8' },
+    ),
+    (error) => {
+      assert(error instanceof Error);
+      assert.equal(error.code, 2);
+      assert.match(error.stderr, /Unknown backend/);
+      return true;
+    },
+  );
+});
+
+test('preserves conditional support descriptors', async () => {
+  // Given: a feature is gated by targetSdkVersion rather than a plain Lynx version.
+  // When: compatibility is queried with a numeric Lynx target.
+  const result = await query(
+    'grid-template-columns',
+    '--feature',
+    'max-content',
+    '--backend',
+    'android',
+    '--lynx-version',
+    '3.1',
+  );
+
+  // Then: the condition is preserved instead of being misclassified by numeric comparison.
+  assert.equal(result.compatibility[0].version_added, 'targetSdkVersion 3.1');
+  assert.equal(result.compatibility[0].availability, 'conditional');
+});
+
+test('accepts optional feature metadata and array notes', async () => {
+  // Given: cursor features omit status and grid-column support uses note arrays.
+  // When: both definitions are queried.
+  const cursor = await query('cursor', '--backend', 'clay_macos');
+  const gridColumn = await query('grid-column', '--backend', 'android');
+
+  // Then: both published shapes are returned without schema loss.
+  assert.equal(cursor.compatibility[0].availability, 'available');
+  assert.equal(gridColumn.compatibility[0].notes.length, 3);
+  assert.match(
+    gridColumn.compatibility[0].notes[0],
+    /enableGridPlacementShorthands/,
+  );
+});
+
+test('queries Lynx properties whose names start with a hyphen', async () => {
+  // Given: -x-auto-font-size is a published Lynx CSS property.
+  // When: it is passed in the normal positional property slot.
+  const result = await query('-x-auto-font-size', '--backend', 'android');
+
+  // Then: Commander does not reinterpret the property as an option.
+  assert.equal(result.property.name, '-x-auto-font-size');
+});
+
+test('keeps command options distinct from leading-hyphen properties', async () => {
+  // Given: a regular option appears before the positional property.
+  // When: the command is invoked in Commander-supported option-first order.
+  const result = await query('--backend', 'android', '-x-auto-font-size');
+
+  // Then: the option and property are both interpreted correctly.
+  assert.equal(result.property.name, '-x-auto-font-size');
+  assert.equal(result.compatibility[0].backend, 'android');
+});
+
+test('keeps leading-hyphen option values distinct from properties', async () => {
+  // Given: a feature-like option value starts with a hyphen.
+  // When: it is passed after the regular display property.
+  await assert.rejects(
+    execFileAsync(
+      process.execPath,
+      [cliPath.pathname, 'display', '--feature', '-not-a-feature'],
+      { encoding: 'utf8' },
+    ),
+    (error) => {
+      assert(error instanceof Error);
+
+      // Then: the option value remains attached to display.
+      assert.equal(error.code, 2);
+      assert.match(error.stderr, /Unknown feature display\.-not-a-feature/);
+      return true;
+    },
+  );
+});
+
+test('prints help without interpreting it as a CSS property', async () => {
+  // Given: the standard help option.
+  // When: help is requested without a property.
+  const { stdout } = await execFileAsync(
+    process.execPath,
+    [cliPath.pathname, '--help'],
+    { encoding: 'utf8' },
+  );
+
+  // Then: Commander prints usage and exits successfully.
+  assert.match(stdout, /Usage: query-css-compat/);
+});
+
+test("preserves Commander's short help option", async () => {
+  // Given: Commander also exposes the short help form.
+  // When: -h is passed without a property.
+  const { stdout } = await execFileAsync(
+    process.execPath,
+    [cliPath.pathname, '-h'],
+    { encoding: 'utf8' },
+  );
+
+  // Then: it prints usage instead of becoming a CSS property.
+  assert.match(stdout, /Usage: query-css-compat/);
+});
+
+test('uses published names for all exceptional leading-hyphen files', async () => {
+  // Given: four package filenames omit one hyphen from their definition name.
+  const properties = [
+    '-x-caret-gradient',
+    '-x-caret-width',
+    '-x-caret-height',
+    '-x-caret-radius',
+  ];
+
+  // When: each published definition name is queried.
+  for (const property of properties) {
+    const result = await query(property);
+
+    // Then: lookup verifies the JSON name rather than exposing the filename quirk.
+    assert.equal(result.property.name, property);
+  }
+});
+
+test('rejects a filename-derived name that is not a published property', async () => {
+  // Given: x-caret-gradient appears only as a filename suffix.
+  // When: the missing-hyphen spelling is queried.
+  await assert.rejects(
+    execFileAsync(process.execPath, [cliPath.pathname, 'x-caret-gradient'], {
+      encoding: 'utf8',
+    }),
+    (error) => {
+      assert(error instanceof Error);
+      assert.equal(error.code, 2);
+      assert.match(error.stderr, /Unknown CSS property/);
+      return true;
+    },
+  );
+});
+
+test('accepts either published spec_url representation', async () => {
+  // Given: text-decoration-thickness publishes spec_url as a string.
+  // When: its compatibility is queried.
+  const result = await query(
+    'text-decoration-thickness',
+    '--backend',
+    'android',
+  );
+
+  // Then: the definition parses just like definitions with spec_url arrays.
+  assert.equal(result.compatibility[0].availability, 'available');
+});
+
+test('queries case-sensitive and function-like compat feature keys', async () => {
+  // Given: published compat_data uses keys such as circle(), Flex, and rotateX.
+  // When: those keys are queried verbatim.
+  const circle = await query('clip-path', '--feature', 'circle()');
+  const flex = await query('gap', '--feature', 'Flex');
+  const rotateX = await query('transform', '--feature', 'rotateX');
+
+  // Then: each package-native key resolves without normalization.
+  assert.equal(circle.feature, 'circle()');
+  assert.equal(flex.feature, 'Flex');
+  assert.equal(rotateX.feature, 'rotateX');
+});
+
+test('preserves nested compatibility feature data', async () => {
+  // Given: linear-direction publishes nested compatibility feature entries.
+  // When: its definition is queried.
+  const result = await query('linear-direction');
+
+  // Then: recursive data is preserved rather than stripped by validation.
+  assert.ok(
+    result.property.compat_data['linear-direction'].support_linear_direction
+      .nested_value_1.__compat,
+  );
+});

--- a/packages/skills/lynx-check-css-support/test/schema-validation.test.mjs
+++ b/packages/skills/lynx-check-css-support/test/schema-validation.test.mjs
@@ -1,0 +1,47 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
+import { cp, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+const scriptsRoot = new URL('../scripts', import.meta.url);
+
+test('rejects unreviewed fields in bundled definitions', async (t) => {
+  // Given: a future package adds a field that this release does not understand.
+  const root = await mkdtemp(join(tmpdir(), 'lynx-css-schema-'));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const copiedScripts = join(root, 'scripts');
+  await cp(scriptsRoot, copiedScripts, { recursive: true });
+  const definitionPath = join(
+    copiedScripts,
+    'css-defines',
+    'css_defines',
+    '24-display.json',
+  );
+  const definition = JSON.parse(await readFile(definitionPath, 'utf8'));
+  definition.future_field = 'must be reviewed before use';
+  await writeFile(definitionPath, `${JSON.stringify(definition)}\n`);
+
+  // When: the modified definition is queried through the copied CLI.
+  await assert.rejects(
+    execFileAsync(
+      process.execPath,
+      [join(copiedScripts, 'query-css-compat.mjs'), 'display', '--json'],
+      { encoding: 'utf8' },
+    ),
+    (error) => {
+      assert(error instanceof Error);
+
+      // Then: schema drift fails closed instead of being stripped silently.
+      assert.equal(error.code, 2);
+      assert.match(error.stderr, /future_field/);
+      return true;
+    },
+  );
+});

--- a/packages/skills/lynx-check-css-support/tsconfig.json
+++ b/packages/skills/lynx-check-css-support/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "declaration": false,
+    "declarationMap": false,
+    "emitDeclarationOnly": false,
+    "isolatedDeclarations": false,
+    "noEmit": true,
+    "rootDir": "./src",
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,6 +39,9 @@ importers:
       '@lynx-js/skill-lynx-a2ui':
         specifier: workspace:*
         version: link:packages/skills/lynx-a2ui
+      '@lynx-js/skill-lynx-check-css-support':
+        specifier: workspace:*
+        version: link:packages/skills/lynx-check-css-support
       '@lynx-js/skill-lynx-debug-info-remapping':
         specifier: workspace:*
         version: link:packages/skills/lynx-debug-info-remapping
@@ -239,6 +242,33 @@ importers:
         specifier: ^5.9.3
         version: 5.9.3
 
+  packages/skills/lynx-a2ui: {}
+
+  packages/skills/lynx-check-css-support:
+    dependencies:
+      '@lynx-js/css-defines':
+        specifier: 0.0.16
+        version: 0.0.16
+    devDependencies:
+      '@rslib/core':
+        specifier: catalog:rstack
+        version: 0.23.0(@microsoft/api-extractor@7.56.2(@types/node@24.13.2))(core-js@3.49.0)(typescript@5.9.3)
+      '@types/node':
+        specifier: ^24.10.4
+        version: 24.13.2
+      commander:
+        specifier: ^13.1.0
+        version: 13.1.0
+      ky:
+        specifier: ^1.14.3
+        version: 1.14.3
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      zod:
+        specifier: ^4.3.5
+        version: 4.4.3
+
   packages/skills/lynx-debug-info-remapping:
     devDependencies:
       '@rslib/core':
@@ -274,8 +304,6 @@ importers:
       obug:
         specifier: ^2.1.3
         version: 2.1.3
-
-  packages/skills/lynx-a2ui: {}
 
   packages/skills/lynx-typescript: {}
 
@@ -770,6 +798,9 @@ packages:
     resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
     engines: {node: '>=18.0.0'}
 
+  '@lynx-js/css-defines@0.0.16':
+    resolution: {integrity: sha512-eeOzMWp4bO1y1gd+uMthaRr3HPaWjWsR92CTPjiaSS4JUqX92mM17pG97MNe+OFeHTm5ltIBjhCJa8TuE3ir5w==}
+
   '@lynx-js/skill-lynx-trace-analysis@0.0.6':
     resolution: {integrity: sha512-2vvoMidxnmaxxtrkLFOXy6GK7nXtWC5m7dqLWPacnHm7FmNBRjVPrQCC49v5X8tAcuN2LQjkcTu+ebIYvfq4/w==}
     engines: {node: '>=18'}
@@ -1248,6 +1279,10 @@ packages:
 
   colorette@2.0.20:
     resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
+
+  commander@13.1.0:
+    resolution: {integrity: sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==}
+    engines: {node: '>=18'}
 
   commander@14.0.3:
     resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
@@ -1733,6 +1768,10 @@ packages:
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
+  ky@1.14.3:
+    resolution: {integrity: sha512-9zy9lkjac+TR1c2tG+mkNSVlyOpInnWdSMiue4F+kq8TwJSgv6o8jhLRg8Ho6SnZ9wOYUq/yozts9qQCfk7bIw==}
+    engines: {node: '>=18'}
 
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
@@ -2382,6 +2421,9 @@ packages:
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
+
   zx@8.8.5:
     resolution: {integrity: sha512-SNgDF5L0gfN7FwVOdEFguY3orU5AkfFZm9B5YSHog/UDHv+lvmd82ZAsOenOkQixigwH2+yyH198AwNdKhj+RA==}
     engines: {node: '>= 12.17.0'}
@@ -2786,6 +2828,8 @@ snapshots:
   '@isaacs/fs-minipass@4.0.1':
     dependencies:
       minipass: 7.1.2
+
+  '@lynx-js/css-defines@0.0.16': {}
 
   '@lynx-js/skill-lynx-trace-analysis@0.0.6': {}
 
@@ -3498,6 +3542,8 @@ snapshots:
 
   colorette@2.0.20: {}
 
+  commander@13.1.0: {}
+
   commander@14.0.3: {}
 
   concat-map@0.0.1: {}
@@ -3996,6 +4042,8 @@ snapshots:
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
+
+  ky@1.14.3: {}
 
   levn@0.4.1:
     dependencies:
@@ -4582,5 +4630,7 @@ snapshots:
       zod: 3.25.76
 
   zod@3.25.76: {}
+
+  zod@4.4.3: {}
 
   zx@8.8.5: {}


### PR DESCRIPTION
## Summary

- add the publishable `@lynx-js/skill-lynx-check-css-support` workspace package
- bundle the build-pinned `@lynx-js/css-defines@0.0.16` data with a CLI that queries property/feature support by backend and Lynx version
- add a standalone `--check-updates` mode that compares the bundled version with the latest numeric version published to npm
- keep compatibility queries fully local and make the update check read-only: it never downloads, installs, caches, or modifies dataset files
- bound the registry request with a fixed HTTPS endpoint, 5-second timeout, no retries or redirects, a 64 KiB response limit, and strict version-only validation
- fail closed on unknown compatibility schema fields and unverified feature queries while preserving recursive nested compatibility data
- add task/trigger evals, Codex UI metadata, marketplace export registration, README documentation, and a minor changeset
- route behavior/semantics questions to the public Lynx documentation instead of the internal-only `lynx-api-docs` skill

## Why

The skill's data source is the public `@lynx-js/css-defines` package, so its implementation and distribution fit the open-source Lynx skills marketplace. Compatibility decisions continue to use the bundled, reviewed dataset. The optional freshness check only reports whether a newer package version exists; applying that version still requires a normal reviewed skill release.

## Validation

- `pnpm -F @lynx-js/skill-lynx-check-css-support test` (30/30 passing)
- deterministic update-check coverage for newer/current/older/invalid/oversized metadata, network failure, every mixed-mode filter, and the existing required-property contract
- exhaustive CLI probe of all 236 bundled definitions with lossless property output
- `pnpm eval:skill:check -- --skill-path packages/skills/lynx-check-css-support` (5 task evals, 25 expectations, 18 trigger evals, 100%)
- skill `quick_validate.py`
- targeted Biome and ESLint checks
- `pnpm -r build`
- `pnpm build` and exported-skill validation (35 passing, 1 expected skip)
- manual CLI QA in a terminal session: live npm update check, exported-artifact update check, normal compatibility query, invalid mixed mode (exit 1), unverified null-compat feature (exit 2), and `--help`
- source and exported CLI artifacts have identical SHA-256 hashes

## Repository baseline

The latest `main` Test workflow is already failing on unrelated devtool-connector Biome diagnostics: https://github.com/lynx-community/skills/actions/runs/29222180267. The new package passes targeted Biome, ESLint, typecheck, build, and tests.
