### PR TITLE
chore: record manually published skill releases

### DIFF
--- a/.changeset/fuzzy-styles-check.md
+++ b/.changeset/fuzzy-styles-check.md
@@ -1,5 +1,0 @@
----
-"@lynx-js/skill-lynx-check-css-support": minor
----
-
-Add a Lynx CSS support-checking skill backed by `@lynx-js/css-defines`, including a read-only dataset update check.

--- a/.changeset/tidy-a2ui-skill.md
+++ b/.changeset/tidy-a2ui-skill.md
@@ -1,5 +1,0 @@
----
-"@lynx-js/skill-lynx-a2ui": minor
----
-
-Add the Lynx A2UI generation skill package.

--- a/packages/skills/lynx-a2ui/package.json
+++ b/packages/skills/lynx-a2ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lynx-js/skill-lynx-a2ui",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "description": "Generate A2UI v0.9 JSON protocol messages for Lynx GenUI.",
   "repository": {
     "url": "https://github.com/lynx-community/skills"
@@ -16,5 +16,8 @@
   },
   "engines": {
     "node": ">=18"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/skills/lynx-check-css-support/package.json
+++ b/packages/skills/lynx-check-css-support/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lynx-js/skill-lynx-check-css-support",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "description": "Check Lynx CSS support by property, feature, backend, and Lynx version",
   "repository": {
     "url": "https://github.com/lynx-community/skills"
@@ -29,5 +29,8 @@
   },
   "engines": {
     "node": ">=18.17"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }


### PR DESCRIPTION
## Summary

- record `0.1.0` and public publish configuration for `@lynx-js/skill-lynx-a2ui`
- record `0.1.0` and public publish configuration for `@lynx-js/skill-lynx-check-css-support`
- remove both pending changesets so Changesets does not publish the packages again

## Why

Both packages were published manually, but their changesets remained on `main` and were already being consumed by the open Changesets release PR. Keeping them would create a duplicate release attempt.

## Impact

The package manifests now reflect the manually published versions, and the automated release flow will no longer try to release these two packages from the stale changesets.

## Validation

- `pnpm --filter @lynx-js/skill-lynx-check-css-support test` (30 tests passed)
- `pnpm --filter @lynx-js/skill-lynx-a2ui build`
- `pnpm exec biome check packages/skills/lynx-a2ui/package.json packages/skills/lynx-check-css-support/package.json`
- `git diff --check`
- `pnpm check` was also run; it is currently blocked by pre-existing Biome diagnostics under `packages/mcp-servers/devtool-connector`, unrelated to this change