### PR TITLE
test: add lynx-a2ui eval coverage

### DIFF
--- a/.changeset/quiet-a2ui-evals.md
+++ b/.changeset/quiet-a2ui-evals.md
@@ -1,0 +1,4 @@
+---
+---
+
+Add CI eval coverage for the Lynx A2UI skill without changing its published runtime.

--- a/packages/skills/lynx-a2ui/evals/evals.json
+++ b/packages/skills/lynx-a2ui/evals/evals.json
@@ -1,0 +1,36 @@
+{
+  "skill_name": "lynx-a2ui",
+  "description": "End-to-end task evals for generating catalog-valid A2UI v0.9 message streams for a fresh data-bound surface and for applying the smallest valid patch after a user action.",
+  "evals": [
+    {
+      "id": 1,
+      "name": "fresh-data-bound-rsvp-form",
+      "prompt": "Fetch the latest default Lynx GenUI A2UI catalog, then generate a compact RSVP form as A2UI v0.9 messages. The form needs a fixed title, a data-bound name input, a data-bound attending toggle, and a submit button. Initialize the name to an empty string and attending to false. The button must emit an event named `submit_rsvp` whose context contains the current name and attending values. Use surface id `main` and return only the final protocol payload.",
+      "expected_output": "A pretty-printed JSON-only A2UI v0.9 message array that creates the main surface with the fetched catalog id, initializes the form data before any binding reads it, and defines one flat, catalog-valid root component graph containing the requested inputs and submit action.",
+      "expectations": [
+        "The response contains only a parseable, pretty-printed JSON array with no Markdown fence, prose, comments, HTML, CSS, JavaScript, or trailing commas.",
+        "Every array item has `version` equal to `v0.9`, and the fresh response orders `createSurface` before `updateDataModel` and the first `updateComponents` message.",
+        "The `createSurface` message uses surface id `main` and the `catalogId` from the fetched default Lynx GenUI A2UI catalog.",
+        "The data model initializes both the name as an empty string and attending as false before components bind to those values.",
+        "The first `updateComponents` message contains exactly one component whose id is `root`; all component ids are unique kebab-case ids, and child relationships use id references rather than inline nested components.",
+        "Components use property-based `component` discriminators and only component names, props, dynamic value shapes, and action shapes allowed by the fetched catalog.",
+        "The requested input and toggle read the initialized data paths, and the submit button emits `submit_rsvp` with context bindings for the current name and attending values."
+      ],
+      "files": []
+    },
+    {
+      "id": 2,
+      "name": "action-response-data-only-patch",
+      "prompt": "The existing A2UI surface `main` already has a status Text component bound to `/status/message`. Respond to this latest user input with the smallest valid A2UI v0.9 patch, and return only the protocol payload:\n\nA2UI_USER_ACTION: {\"surfaceId\":\"main\",\"action\":{\"name\":\"submit_rsvp\",\"context\":{\"name\":\"Mina\",\"attending\":true}}}\n\nSet the status to a success result that confirms Mina is attending. Do not replace the whole UI.",
+      "expected_output": "A non-empty JSON-only A2UI v0.9 patch for the existing main surface, using a data-model update for /status and avoiding surface recreation or unnecessary component replacement.",
+      "expectations": [
+        "The response contains only a non-empty, parseable JSON array whose messages all use `version` equal to `v0.9`.",
+        "The patch keeps surface id `main` and does not emit `createSurface`, `deleteSurface`, or a replacement fresh UI.",
+        "An `updateDataModel` message updates `/status` with a success value whose message confirms that Mina is attending.",
+        "The response does not emit `updateComponents`, because the prompt states that an existing Text component already reads `/status/message` and no visible structure needs to change.",
+        "The response does not include the original form definition or claim that the RSVP succeeded before processing the supplied action."
+      ],
+      "files": []
+    }
+  ]
+}

--- a/packages/skills/lynx-a2ui/evals/trigger_eval.json
+++ b/packages/skills/lynx-a2ui/evals/trigger_eval.json
@@ -1,0 +1,34 @@
+[
+  {
+    "query": "把“活动报名表”这个自然语言需求转换成 A2UI v0.9 JSON 消息，直接给 A2UI renderer 渲染。",
+    "should_trigger": true
+  },
+  {
+    "query": "Fetch the latest Lynx GenUI catalog and return createSurface, updateDataModel, and updateComponents messages for a trip picker.",
+    "should_trigger": true
+  },
+  {
+    "query": "A2UI_USER_ACTION 已经提交了表单，请给现有 surface 返回最小的 updateDataModel patch，不要重建页面。",
+    "should_trigger": true
+  },
+  {
+    "query": "Use this custom catalog JSON to generate a catalog-valid A2UI product comparison surface with data bindings and actions.",
+    "should_trigger": true
+  },
+  {
+    "query": "在 ReactLynx 项目里实现 A2UI renderer，并注册一套自定义 catalog components，代码应该怎么组织？",
+    "should_trigger": false
+  },
+  {
+    "query": "解释 A2UI、MCP 和 AG UI 的架构差异以及它们各自适合的传输场景。",
+    "should_trigger": false
+  },
+  {
+    "query": "用 ReactLynx TSX 写一个带姓名输入框和确认按钮的活动报名页面。",
+    "should_trigger": false
+  },
+  {
+    "query": "Generate an OpenAPI JSON Schema for my REST endpoint's request and response bodies.",
+    "should_trigger": false
+  }
+]

--- a/packages/skills/lynx-a2ui/src/sync-from-lynx-stack.mjs
+++ b/packages/skills/lynx-a2ui/src/sync-from-lynx-stack.mjs
@@ -10,8 +10,7 @@ import { fileURLToPath } from 'node:url';
 
 const DEFAULT_REPO = 'https://github.com/lynx-family/lynx-stack.git';
 const DEFAULT_REF = 'main';
-const DEFAULT_SOURCE_PATH =
-  'packages/genui/a2ui/skills/lynx-a2ui/SKILL.md';
+const DEFAULT_SOURCE_PATH = 'packages/genui/a2ui/skills/lynx-a2ui/SKILL.md';
 
 const scriptDir = dirname(fileURLToPath(import.meta.url));
 const packageDir = resolve(scriptDir, '..');
@@ -52,7 +51,7 @@ function parseArgs(argv) {
       case '--help':
       case '-h':
         printHelp();
-        process.exit(0);
+        return process.exit(0);
       default:
         throw new Error(`Unknown argument: ${arg}`);
     }


### PR DESCRIPTION
## Summary

- add task evals for fresh A2UI surfaces and action-response patches
- add positive and negative trigger eval coverage
- keep the sync CLI help path's return value explicit
- add an empty changeset because these CI/eval updates do not change the published runtime

## Root cause

The all-skill eval workflow discovers the generated `lynx-a2ui` skill, but the package did not provide `evals/evals.json` or `evals/trigger_eval.json`. That made definition, task, and trigger evaluation fail for unrelated skill pull requests.

## Merge order

Merge this PR before #106. Its current Windows test failure is the existing path-conversion baseline fixed by #106; code style, changeset, skill validation, and the A2UI eval-definition step pass here.

## Validation

- `pnpm --filter @lynx-js/skill-lynx-a2ui build`
- `pnpm eval:skill:check -- --skill-path packages/skills/lynx-a2ui`
- targeted Biome check
- `pnpm changeset status --since=origin/main`