### PR TITLE
fix: make CSS support tests portable on Windows

### DIFF
--- a/.changeset/quiet-css-windows-tests.md
+++ b/.changeset/quiet-css-windows-tests.md
@@ -1,0 +1,4 @@
+---
+---
+
+Make the Lynx CSS support test suite portable on Windows without changing the published runtime.

--- a/packages/skills/lynx-check-css-support/test/check-updates.test.mjs
+++ b/packages/skills/lynx-check-css-support/test/check-updates.test.mjs
@@ -7,18 +7,20 @@ import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import test from 'node:test';
-import { pathToFileURL } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import { promisify } from 'node:util';
 
 const execFileAsync = promisify(execFile);
-const cliPath = new URL('../scripts/query-css-compat.mjs', import.meta.url);
+const cliPath = fileURLToPath(
+  new URL('../scripts/query-css-compat.mjs', import.meta.url),
+);
 
 async function runWithPreload(t, preloadSource, ...args) {
   const root = await mkdtemp(join(tmpdir(), 'lynx-css-update-check-'));
   t.after(() => rm(root, { recursive: true, force: true }));
   const preloadPath = join(root, 'mock-fetch.mjs');
   await writeFile(preloadPath, preloadSource);
-  return execFileAsync(process.execPath, [cliPath.pathname, ...args], {
+  return execFileAsync(process.execPath, [cliPath, ...args], {
     encoding: 'utf8',
     env: {
       ...process.env,
@@ -200,7 +202,7 @@ test('still requires a property for compatibility queries', async () => {
   // Given: neither a property nor the standalone update-check flag is supplied.
   // When: the CLI is invoked without arguments.
   await assert.rejects(
-    execFileAsync(process.execPath, [cliPath.pathname], { encoding: 'utf8' }),
+    execFileAsync(process.execPath, [cliPath], { encoding: 'utf8' }),
     (error) => {
       assert(error instanceof Error);
 

--- a/packages/skills/lynx-check-css-support/test/compatibility-status.test.mjs
+++ b/packages/skills/lynx-check-css-support/test/compatibility-status.test.mjs
@@ -4,10 +4,13 @@
 import assert from 'node:assert/strict';
 import { execFile } from 'node:child_process';
 import test from 'node:test';
+import { fileURLToPath } from 'node:url';
 import { promisify } from 'node:util';
 
 const execFileAsync = promisify(execFile);
-const cliPath = new URL('../scripts/query-css-compat.mjs', import.meta.url);
+const cliPath = fileURLToPath(
+  new URL('../scripts/query-css-compat.mjs', import.meta.url),
+);
 const deprecatedProperty = 'linear-direction';
 const deprecatedFeature = 'support_linear_orientation';
 
@@ -16,13 +19,7 @@ test('returns the selected compatibility status in JSON', async () => {
   // When: the property is queried as JSON.
   const { stdout } = await execFileAsync(
     process.execPath,
-    [
-      cliPath.pathname,
-      deprecatedProperty,
-      '--feature',
-      deprecatedFeature,
-      '--json',
-    ],
+    [cliPath, deprecatedProperty, '--feature', deprecatedFeature, '--json'],
     { encoding: 'utf8' },
   );
   const result = JSON.parse(stdout);
@@ -39,7 +36,7 @@ test('prints a deprecated warning in human-readable output', async () => {
   // When: the property is queried in the default human-readable format.
   const { stdout } = await execFileAsync(
     process.execPath,
-    [cliPath.pathname, deprecatedProperty, '--feature', deprecatedFeature],
+    [cliPath, deprecatedProperty, '--feature', deprecatedFeature],
     { encoding: 'utf8' },
   );
 

--- a/packages/skills/lynx-check-css-support/test/query-css-compat.test.mjs
+++ b/packages/skills/lynx-check-css-support/test/query-css-compat.test.mjs
@@ -4,15 +4,18 @@
 import assert from 'node:assert/strict';
 import { execFile } from 'node:child_process';
 import test from 'node:test';
+import { fileURLToPath } from 'node:url';
 import { promisify } from 'node:util';
 
 const execFileAsync = promisify(execFile);
-const cliPath = new URL('../scripts/query-css-compat.mjs', import.meta.url);
+const cliPath = fileURLToPath(
+  new URL('../scripts/query-css-compat.mjs', import.meta.url),
+);
 
 async function query(...args) {
   const { stdout } = await execFileAsync(
     process.execPath,
-    [cliPath.pathname, ...args, '--json'],
+    [cliPath, ...args, '--json'],
     { encoding: 'utf8' },
   );
   return JSON.parse(stdout);
@@ -82,7 +85,7 @@ test('rejects a feature query when compat_data is null', async () => {
   await assert.rejects(
     execFileAsync(
       process.execPath,
-      [cliPath.pathname, 'content', '--feature', 'definitely-not-real'],
+      [cliPath, 'content', '--feature', 'definitely-not-real'],
       { encoding: 'utf8' },
     ),
     (error) => {
@@ -105,7 +108,7 @@ test('rejects an unknown CSS property', async () => {
   try {
     await execFileAsync(
       process.execPath,
-      [cliPath.pathname, 'definitely-not-a-property'],
+      [cliPath, 'definitely-not-a-property'],
       { encoding: 'utf8' },
     );
     assert.fail('Expected the CLI to reject an unknown property');
@@ -124,7 +127,7 @@ test('rejects inherited object properties as backend names', async () => {
   await assert.rejects(
     execFileAsync(
       process.execPath,
-      [cliPath.pathname, 'display', '--backend', 'constructor'],
+      [cliPath, 'display', '--backend', 'constructor'],
       { encoding: 'utf8' },
     ),
     (error) => {
@@ -194,7 +197,7 @@ test('keeps leading-hyphen option values distinct from properties', async () => 
   await assert.rejects(
     execFileAsync(
       process.execPath,
-      [cliPath.pathname, 'display', '--feature', '-not-a-feature'],
+      [cliPath, 'display', '--feature', '-not-a-feature'],
       { encoding: 'utf8' },
     ),
     (error) => {
@@ -213,7 +216,7 @@ test('prints help without interpreting it as a CSS property', async () => {
   // When: help is requested without a property.
   const { stdout } = await execFileAsync(
     process.execPath,
-    [cliPath.pathname, '--help'],
+    [cliPath, '--help'],
     { encoding: 'utf8' },
   );
 
@@ -224,11 +227,9 @@ test('prints help without interpreting it as a CSS property', async () => {
 test("preserves Commander's short help option", async () => {
   // Given: Commander also exposes the short help form.
   // When: -h is passed without a property.
-  const { stdout } = await execFileAsync(
-    process.execPath,
-    [cliPath.pathname, '-h'],
-    { encoding: 'utf8' },
-  );
+  const { stdout } = await execFileAsync(process.execPath, [cliPath, '-h'], {
+    encoding: 'utf8',
+  });
 
   // Then: it prints usage instead of becoming a CSS property.
   assert.match(stdout, /Usage: query-css-compat/);
@@ -256,7 +257,7 @@ test('rejects a filename-derived name that is not a published property', async (
   // Given: x-caret-gradient appears only as a filename suffix.
   // When: the missing-hyphen spelling is queried.
   await assert.rejects(
-    execFileAsync(process.execPath, [cliPath.pathname, 'x-caret-gradient'], {
+    execFileAsync(process.execPath, [cliPath, 'x-caret-gradient'], {
       encoding: 'utf8',
     }),
     (error) => {


### PR DESCRIPTION
## Summary

- convert file URLs with `fileURLToPath` in all CSS support CLI tests
- remove direct `.pathname` use that produces invalid Windows drive paths
- add an empty changeset because this is test-only and does not change the published runtime

## Root cause

On Windows, passing a file URL pathname to `node.exe` produced paths such as `D:\\D:\\a\\skills\\...`, causing 11 tests to fail with `ERR_MODULE_NOT_FOUND`. Converting the URL with Node's `fileURLToPath` yields the native platform path.

## Merge order

Merge this PR after #105. The Windows and Ubuntu jobs pass here; its current code-style/eval baseline failures come from the A2UI files fixed by #105.

## Validation

- `pnpm --filter @lynx-js/skill-lynx-check-css-support test` (30/30)
- GitHub Actions Windows test job
- targeted Biome check
- `pnpm changeset status --since=origin/main`