### PR TITLE
feat: add lynx-api-docs skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ A collection of [Agent skills](https://agentskills.io/) for [Lynx](https://lynxj
 ## Available Skills
 
 - [reactlynx-best-practices](./packages/skills/reactlynx-best-practices): ReactLynx dual-thread best practices, static analysis, and auto-fixes.
+- [lynx-api-docs](./packages/skills/lynx-api-docs): Use authoritative public Lynx API documentation for elements, CSS, layouts, web migration, and common implementation patterns.
 - [lynx-check-css-support](./packages/skills/lynx-check-css-support): Check Lynx CSS property and feature support by backend and Lynx version.
 - [lynx-debug-info-remapping](./packages/skills/lynx-debug-info-remapping): Remap `function_id:pc_index` runtime errors to original source positions with `debug-info.json`.
 - [lynx-devtool](./packages/skills/lynx-devtool): Inspect and debug Lynx apps through DevTool CLI, CDP/App commands, console logs, sources, and screenshots.

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@lynx-js/ai-plugin-reactlynx": "workspace:*",
     "@lynx-js/skill-habitat-usage": "workspace:*",
     "@lynx-js/skill-lynx-a2ui": "workspace:*",
+    "@lynx-js/skill-lynx-api-docs": "workspace:*",
     "@lynx-js/skill-lynx-check-css-support": "workspace:*",
     "@lynx-js/skill-lynx-debug-info-remapping": "workspace:*",
     "@lynx-js/skill-lynx-devtool": "workspace:*",

--- a/packages/skills/lynx-api-docs/.gitignore
+++ b/packages/skills/lynx-api-docs/.gitignore
@@ -1,0 +1,11 @@
+# Build outputs generated from @lynx-js/lynx-api-docs
+SKILL.md
+best-practices.md
+quick-reference.md
+config/
+css/
+elements/
+examples/
+layout/
+lynx-vs-web/
+patterns/

--- a/packages/skills/lynx-api-docs/build.mjs
+++ b/packages/skills/lynx-api-docs/build.mjs
@@ -1,0 +1,44 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import { cp, readdir, readFile, writeFile } from 'node:fs/promises';
+import { createRequire } from 'node:module';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const require = createRequire(import.meta.url);
+const packageRoot = dirname(
+  require.resolve('@lynx-js/lynx-api-docs/package.json'),
+);
+const sourceRoot = resolve(packageRoot, 'skills', 'using-lynx-api-docs');
+const targetRoot = dirname(fileURLToPath(import.meta.url));
+const excludedEntries = new Set([
+  'AGENTS.md',
+  'AGENTS.public.md',
+  'CHANGELOG.md',
+  'README.md',
+  'README.public.md',
+]);
+
+for (const entry of await readdir(sourceRoot)) {
+  if (excludedEntries.has(entry)) {
+    continue;
+  }
+  await cp(resolve(sourceRoot, entry), resolve(targetRoot, entry), {
+    recursive: true,
+    force: true,
+  });
+}
+
+const skillPath = resolve(targetRoot, 'SKILL.md');
+const skill = await readFile(skillPath, 'utf8');
+const normalizedSkill = skill.replace(
+  /^name: using-lynx-api-docs$/m,
+  'name: lynx-api-docs',
+);
+if (normalizedSkill === skill) {
+  throw new Error(
+    'Expected the upstream skill name to be "using-lynx-api-docs".',
+  );
+}
+await writeFile(skillPath, normalizedSkill);

--- a/packages/skills/lynx-api-docs/package.json
+++ b/packages/skills/lynx-api-docs/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@lynx-js/skill-lynx-api-docs",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Use authoritative public Lynx API documentation from coding agents",
+  "type": "module",
+  "files": [
+    "SKILL.md",
+    "best-practices.md",
+    "quick-reference.md",
+    "config",
+    "css",
+    "elements",
+    "examples",
+    "layout",
+    "lynx-vs-web",
+    "patterns"
+  ],
+  "scripts": {
+    "build": "node ./build.mjs",
+    "test": "node --test test.mjs"
+  },
+  "devDependencies": {
+    "@lynx-js/lynx-api-docs": "0.3.8"
+  },
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/packages/skills/lynx-api-docs/test.mjs
+++ b/packages/skills/lynx-api-docs/test.mjs
@@ -1,0 +1,22 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const packageRoot = dirname(fileURLToPath(import.meta.url));
+
+test('builds the public Lynx API documentation skill', async () => {
+  const skill = await readFile(resolve(packageRoot, 'SKILL.md'), 'utf8');
+  assert.match(skill, /^---\nname: lynx-api-docs\n/m);
+  assert.match(skill, /elements\/<element-name>\.md/);
+
+  const elementDocs = await readFile(
+    resolve(packageRoot, 'elements', 'scroll-view.md'),
+    'utf8',
+  );
+  assert.match(elementDocs, /scroll-view/);
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,6 +39,9 @@ importers:
       '@lynx-js/skill-lynx-a2ui':
         specifier: workspace:*
         version: link:packages/skills/lynx-a2ui
+      '@lynx-js/skill-lynx-api-docs':
+        specifier: workspace:*
+        version: link:packages/skills/lynx-api-docs
       '@lynx-js/skill-lynx-check-css-support':
         specifier: workspace:*
         version: link:packages/skills/lynx-check-css-support
@@ -246,6 +249,12 @@ importers:
         version: 5.9.3
 
   packages/skills/lynx-a2ui: {}
+
+  packages/skills/lynx-api-docs:
+    devDependencies:
+      '@lynx-js/lynx-api-docs':
+        specifier: 0.3.8
+        version: 0.3.8
 
   packages/skills/lynx-check-css-support:
     dependencies:
@@ -803,6 +812,11 @@ packages:
 
   '@lynx-js/css-defines@0.0.16':
     resolution: {integrity: sha512-eeOzMWp4bO1y1gd+uMthaRr3HPaWjWsR92CTPjiaSS4JUqX92mM17pG97MNe+OFeHTm5ltIBjhCJa8TuE3ir5w==}
+
+  '@lynx-js/lynx-api-docs@0.3.8':
+    resolution: {integrity: sha512-4DSaRkCxdbjrq5vYylBWUqa/JNkMrZlfX2dyfkxdYusJopI/HTmV/OUXzzXM8rxPdb2ihx1kMJY7T8BIUNLf3g==}
+    engines: {node: '>=14'}
+    hasBin: true
 
   '@lynx-js/skill-lynx-openui@0.0.1':
     resolution: {integrity: sha512-A9fRrxBc4I8motIvbO74S/80v9o0WNcQBeB2tR61a5D+MlMsykJSudxxhRw1OlVvqsHHdJRz0cIWPM1Qz841UA==}
@@ -2837,6 +2851,8 @@ snapshots:
       minipass: 7.1.2
 
   '@lynx-js/css-defines@0.0.16': {}
+
+  '@lynx-js/lynx-api-docs@0.3.8': {}
 
   '@lynx-js/skill-lynx-openui@0.0.1': {}
 


### PR DESCRIPTION
## Summary

- add a `lynx-api-docs` workspace wrapper around `@lynx-js/lynx-api-docs@0.3.8`
- export the upstream public API references through the community skills marketplace
- normalize the upstream `using-lynx-api-docs` frontmatter name to the marketplace-compatible `lynx-api-docs` name
- add a focused build test and list the skill in the repository README

The Lynx engine repository remains the source of truth for the generated API documentation. This package only adapts its bundled skill for installation with:

```bash
npx skills add lynx-community/skills -s lynx-api-docs
```

## Verification

- `pnpm --filter @lynx-js/skill-lynx-api-docs build`
- `pnpm --filter @lynx-js/skill-lynx-api-docs test`
- `pnpm build`
- `node --test scripts/validate-skills.test.mjs`
- `pnpm exec biome check packages/skills/lynx-api-docs package.json README.md`
- `pnpm exec eslint packages/skills/lynx-api-docs`
- `pnpm changeset status --since=origin/main`

## Source

https://github.com/lynx-family/lynx/tree/develop/ai/skills/lynx-api-docs