### PR TITLE
fix: harden lynx-api-docs skill build

### DIFF
--- a/evals/lynx-openui/evals.json
+++ b/evals/lynx-openui/evals.json
@@ -1,0 +1,61 @@
+{
+  "skill_name": "lynx-openui",
+  "description": "End-to-end task evals for generating valid OpenUI Lang v0.5 programs for the Lynx OpenUI renderer, including static UI, tool-backed data, mutable input state, mutations, and edit-mode patches.",
+  "evals": [
+    {
+      "id": 1,
+      "name": "static-summary-with-conversational-action",
+      "prompt": "Return raw OpenUI Lang v0.5 only for `<OpenUiRenderer response={...}>`. Build a compact mobile weekly-summary card with title `Weekly Summary`, subtitle `Updated just now`, body lines `Revenue is up 18%.` and `Three accounts need follow-up.`, plus a primary `Show details` button that asks the assistant to show the account details. No tools are available.",
+      "expected_output": "A complete static OpenUI program whose root is declared first and reaches a summary Card and Buttons group, with supported positional component calls and an explicit `@ToAssistant` action.",
+      "expectations": [
+        "The first non-empty line is a `root = Stack(...)` assignment whose references include the visible summary and action sections.",
+        "The program uses only built-in catalog components such as `Card`, `CardHeader`, `TextContent`, `Buttons`, and `Button`, with positional arguments in the documented order.",
+        "The `Show details` button uses `Action([@ToAssistant(\"Show the account details\")])` or an equivalent explicit conversational continuation.",
+        "No `Query` or `Mutation` is emitted because the caller supplied no tool.",
+        "The response contains only one-assignment-per-line OpenUI Lang, with no Markdown fence, prose, JSON, HTML, JSX, or CSS, and every declaration is reachable from `root`."
+      ],
+      "files": []
+    },
+    {
+      "id": 2,
+      "name": "query-backed-repeated-task-list",
+      "prompt": "Generate raw OpenUI Lang v0.5 for a task screen. The host supplies a read tool `list_tasks` accepting `{ status: string }` and returning `{ rows: Array<{ title: string, status: string }> }`. Query open tasks, show the count in the header, render every row as a card with title and status, and add a manual Refresh button. Include representative initial data so the UI renders before the tool resolves.",
+      "expected_output": "A complete OpenUI program using an ordinary `Query` declaration with a shape-correct default result, `@Count` for the header, inline `@Each` for repeated cards, and a visible refresh action that runs the query.",
+      "expectations": [
+        "The program starts with `root = Stack(...)` and declares `tasks = Query(\"list_tasks\", { status: \"open\" }, ...)` on an ordinary identifier rather than a `$` state identifier.",
+        "The Query includes a compact representative default object with a `rows` array whose entries contain both `title` and `status`.",
+        "The visible header derives its count with `@Count(tasks.rows)` or an equivalent documented expression.",
+        "Repeated UI uses `List(@Each(tasks.rows, \"task\", ...))`, keeping every `task`-dependent component inline inside the `@Each` template.",
+        "A visible Refresh button invokes `Action([@Run(tasks)])`; the response invents no additional tool or component and contains only OpenUI Lang."
+      ],
+      "files": []
+    },
+    {
+      "id": 3,
+      "name": "state-bound-input-and-explicit-save",
+      "prompt": "Generate raw OpenUI Lang v0.5 for editing a display name. The host supplies a write tool `save_profile` accepting `{ displayName: string }` and returning `{ ok: boolean }`. Start with `Ada`, bind a short text field directly to mutable state, show the current name, save only when the user taps a primary Save button, and show loading/success/default status text.",
+      "expected_output": "A complete OpenUI program with declared `$displayName` state, same-key TextField binding, an ordinary Mutation that consumes the state, an explicit Save action, and mutation-status-driven feedback.",
+      "expectations": [
+        "The program declares `$displayName = \"Ada\"` and uses that same state value in visible UI and the mutation arguments.",
+        "The TextField uses the documented same-key positional pattern, including `null` for the unused action position and the exact literal name `\"$displayName\"`.",
+        "The write tool is declared as an ordinary identifier such as `save = Mutation(\"save_profile\", { displayName: $displayName })`, not as `$save`.",
+        "The mutation runs only from a visible primary Save button using `Action([@Run(save)])`, not from the input change action.",
+        "Visible feedback branches on `save.status` for loading and success while retaining a default instruction, and the response contains only reachable OpenUI Lang declarations."
+      ],
+      "files": []
+    },
+    {
+      "id": 4,
+      "name": "merge-statements-targeted-patch",
+      "prompt": "The host explicitly uses edit mode with `mergeStatements`. Existing program:\n`root = Stack([header, action], \"column\", false, \"m\", \"stretch\", \"start\")`\n`header = CardHeader(\"Trip\", \"Draft\")`\n`action = Button(\"Open guide\", Action([@ToAssistant(\"Tell me about the trip\")]), \"secondary\")`\nChange only the subtitle to `Ready` and make the existing button open the caller-provided trustworthy URL `https://example.com/trip`. Return the smallest raw OpenUI patch.",
+      "expected_output": "An edit-mode OpenUI patch containing only replacement assignments for `header` and `action`, preserving the unchanged root graph and using `@OpenUrl` with the supplied URL.",
+      "expectations": [
+        "The response includes a replacement `header = CardHeader(\"Trip\", \"Ready\")` assignment.",
+        "The response includes a replacement `action = Button(...)` whose action is `Action([@OpenUrl(\"https://example.com/trip\")])` and whose secondary variant remains valid.",
+        "The unchanged `root` assignment is omitted because the root graph did not change.",
+        "No unchanged statements, invented declarations, prose, Markdown fence, JSON, JSX, or CSS are returned."
+      ],
+      "files": []
+    }
+  ]
+}

--- a/evals/lynx-openui/trigger_eval.json
+++ b/evals/lynx-openui/trigger_eval.json
@@ -1,0 +1,74 @@
+[
+  {
+    "query": "Generate raw OpenUI Lang v0.5 for OpenUiRenderer: a compact mobile summary card with two actions.",
+    "should_trigger": true
+  },
+  {
+    "query": "把这个自然语言 UI 需求转换成只包含 OpenUI DSL 的 response，第一行先声明 root。",
+    "should_trigger": true
+  },
+  {
+    "query": "Use the supplied list_tasks tool in an OpenUI Query and render its rows with inline @Each.",
+    "should_trigger": true
+  },
+  {
+    "query": "Create an OpenUI Mutation flow with $state, an explicit confirmation Button, and success feedback.",
+    "should_trigger": true
+  },
+  {
+    "query": "Write a TextField in OpenUI Lang that binds directly to $city and drives the supplied weather Query.",
+    "should_trigger": true
+  },
+  {
+    "query": "The host uses mergeStatements edit mode; return only the changed OpenUI assignments for this revision.",
+    "should_trigger": true
+  },
+  {
+    "query": "Generate a streaming-friendly OpenUI program using only Stack, Card, Text, Modal, and Button from this catalog.",
+    "should_trigger": true
+  },
+  {
+    "query": "Fix this OpenUI Lang call where named arguments and the missing Stack wrap position shift all later props.",
+    "should_trigger": true
+  },
+  {
+    "query": "Validate that every reference in this Lynx OpenUI response resolves and no statements are orphaned.",
+    "should_trigger": true
+  },
+  {
+    "query": "Implement a new ReactLynx OpenUiRenderer component in TypeScript and add unit tests.",
+    "should_trigger": false
+  },
+  {
+    "query": "Return an A2UI JSON message describing a product card and its click action.",
+    "should_trigger": false
+  },
+  {
+    "query": "Build this mobile card as ReactLynx JSX with view, text, image, and a CSS stylesheet.",
+    "should_trigger": false
+  },
+  {
+    "query": "Which Lynx rendering backends support display grid in SDK 2.0?",
+    "should_trigger": false
+  },
+  {
+    "query": "TypeScript says my custom Lynx element is missing from JSX.IntrinsicElements; write the declaration file.",
+    "should_trigger": false
+  },
+  {
+    "query": "How should I use the @lynx-js/lynx-ui Button component and type its props in ReactLynx?",
+    "should_trigger": false
+  },
+  {
+    "query": "Design an OpenAPI 3.1 specification for a task-management REST service.",
+    "should_trigger": false
+  },
+  {
+    "query": "Create a responsive HTML and Tailwind dashboard that runs in a web browser.",
+    "should_trigger": false
+  },
+  {
+    "query": "Explain general open UI design principles for making an accessible settings screen.",
+    "should_trigger": false
+  }
+]

--- a/packages/skills/lynx-api-docs/build.mjs
+++ b/packages/skills/lynx-api-docs/build.mjs
@@ -1,9 +1,18 @@
 // Copyright 2026 The Lynx Authors. All rights reserved.
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
-import { cp, readdir, readFile, writeFile } from 'node:fs/promises';
+import {
+  cp,
+  mkdir,
+  mkdtemp,
+  readdir,
+  readFile,
+  rename,
+  rm,
+  writeFile,
+} from 'node:fs/promises';
 import { createRequire } from 'node:module';
-import { dirname, resolve } from 'node:path';
+import { basename, dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const require = createRequire(import.meta.url);
@@ -12,6 +21,33 @@ const packageRoot = dirname(
 );
 const sourceRoot = resolve(packageRoot, 'skills', 'using-lynx-api-docs');
 const targetRoot = dirname(fileURLToPath(import.meta.url));
+const packageManifest = JSON.parse(
+  await readFile(resolve(targetRoot, 'package.json'), 'utf8'),
+);
+const protectedEntries = new Set([
+  '.gitignore',
+  'build.mjs',
+  'package.json',
+  'test.mjs',
+  'turbo.json',
+]);
+if (
+  !Array.isArray(packageManifest.files) ||
+  packageManifest.files.some(
+    (entry) =>
+      typeof entry !== 'string' ||
+      entry.length === 0 ||
+      entry !== basename(entry) ||
+      entry === '.' ||
+      entry === '..' ||
+      protectedEntries.has(entry),
+  )
+) {
+  throw new Error(
+    'Expected package.json files to contain safe generated top-level paths.',
+  );
+}
+const generatedEntries = new Set(packageManifest.files);
 const excludedEntries = new Set([
   'AGENTS.md',
   'AGENTS.public.md',
@@ -19,26 +55,91 @@ const excludedEntries = new Set([
   'README.md',
   'README.public.md',
 ]);
-
-for (const entry of await readdir(sourceRoot)) {
-  if (excludedEntries.has(entry)) {
-    continue;
-  }
-  await cp(resolve(sourceRoot, entry), resolve(targetRoot, entry), {
-    recursive: true,
-    force: true,
-  });
-}
-
-const skillPath = resolve(targetRoot, 'SKILL.md');
-const skill = await readFile(skillPath, 'utf8');
-const normalizedSkill = skill.replace(
-  /^name: using-lynx-api-docs$/m,
-  'name: lynx-api-docs',
+const sourceEntries = (await readdir(sourceRoot)).filter(
+  (entry) => !excludedEntries.has(entry),
 );
-if (normalizedSkill === skill) {
-  throw new Error(
-    'Expected the upstream skill name to be "using-lynx-api-docs".',
-  );
+
+for (const entry of sourceEntries) {
+  if (!generatedEntries.has(entry)) {
+    throw new Error(
+      `Upstream output "${entry}" is missing from package.json files.`,
+    );
+  }
 }
-await writeFile(skillPath, normalizedSkill);
+
+const buildRoot = await mkdtemp(resolve(targetRoot, '.lynx-api-docs-build-'));
+const nextRoot = resolve(buildRoot, 'next');
+const previousRoot = resolve(buildRoot, 'previous');
+
+try {
+  await Promise.all([
+    mkdir(nextRoot, { recursive: true }),
+    mkdir(previousRoot, { recursive: true }),
+  ]);
+  await Promise.all(
+    sourceEntries.map((entry) =>
+      cp(resolve(sourceRoot, entry), resolve(nextRoot, entry), {
+        recursive: true,
+        force: true,
+      }),
+    ),
+  );
+
+  const skillPath = resolve(nextRoot, 'SKILL.md');
+  const skill = await readFile(skillPath, 'utf8');
+  const normalizedSkill = skill.replace(
+    /^name: using-lynx-api-docs$/m,
+    'name: lynx-api-docs',
+  );
+  if (normalizedSkill === skill) {
+    throw new Error(
+      'Expected the upstream skill name to be "using-lynx-api-docs".',
+    );
+  }
+  await writeFile(skillPath, normalizedSkill);
+
+  const backedUpEntries = [];
+  const installedEntries = [];
+  try {
+    for (const entry of generatedEntries) {
+      try {
+        await rename(resolve(targetRoot, entry), resolve(previousRoot, entry));
+        backedUpEntries.push(entry);
+      } catch (error) {
+        if (error?.code !== 'ENOENT') {
+          throw error;
+        }
+      }
+    }
+
+    for (const entry of sourceEntries) {
+      await rename(resolve(nextRoot, entry), resolve(targetRoot, entry));
+      installedEntries.push(entry);
+    }
+  } catch (error) {
+    const rollbackErrors = [];
+    for (const entry of installedEntries.reverse()) {
+      try {
+        await rm(resolve(targetRoot, entry), { recursive: true, force: true });
+      } catch (rollbackError) {
+        rollbackErrors.push(rollbackError);
+      }
+    }
+    for (const entry of backedUpEntries.reverse()) {
+      try {
+        await rename(resolve(previousRoot, entry), resolve(targetRoot, entry));
+      } catch (rollbackError) {
+        rollbackErrors.push(rollbackError);
+      }
+    }
+    if (rollbackErrors.length > 0) {
+      throw new AggregateError(
+        [error, ...rollbackErrors],
+        'Failed to install generated documentation and restore prior outputs.',
+      );
+    }
+    throw error;
+  }
+} finally {
+  await rm(buildRoot, { recursive: true, force: true });
+}

--- a/packages/skills/lynx-api-docs/evals/evals.json
+++ b/packages/skills/lynx-api-docs/evals/evals.json
@@ -1,0 +1,62 @@
+{
+  "skill_name": "lynx-api-docs",
+  "description": "End-to-end task evals for retrieving and applying the installed Lynx API documentation when migrating Web UI, choosing Lynx layouts, and using Lynx elements.",
+  "evals": [
+    {
+      "id": 1,
+      "name": "migrate-interactive-web-card",
+      "prompt": "把这个 Web React 卡片迁移成 ReactLynx 组件，并指出关键的平台差异：`<div className=\"card\"><img src={image} alt={title} /><h3>{title}</h3><p>{description}</p><button onClick={open}>Open</button></div>`。不要照搬浏览器 DOM 语义，请先查已安装的 Lynx API 文档再给代码。",
+      "expected_output": "A ReactLynx card using documented Lynx elements and event syntax: `view` for containers, `image` for the image, `text` for all visible text, and a tappable `view` with `bindtap` instead of a Web button with `onClick`, together with the relevant Web-to-Lynx caveats.",
+      "expectations": [
+        "The response applies the installed Web migration and element documentation rather than treating Lynx as a browser DOM.",
+        "The code replaces `div` with `view`, `img` with `image`, and the heading and paragraph with `text` elements.",
+        "All visible strings and expressions, including the button label, are wrapped in `text` rather than appearing directly under `view`.",
+        "The Web `button` and `onClick` are replaced with a Lynx `view` using `bindtap={open}` or an equivalent documented Lynx tap handler.",
+        "The explanation notes at least one relevant Lynx layout or CSS default, such as default Linear layout, `border-box`, or the absence of margin collapsing, instead of assuming Web block-flow behavior."
+      ],
+      "files": []
+    },
+    {
+      "id": 2,
+      "name": "linear-layout-weighted-columns",
+      "prompt": "请用 Lynx 默认的 Linear Layout 写一个横向三栏布局，不要改成 Flexbox：左栏固定 200px，main 和 aside 把剩余宽度按 2:1 分配，三栏在交叉轴居中。给最小 TSX 和 CSS，并解释剩余空间怎么算。",
+      "expected_output": "A documented Linear Layout example with a row container, a fixed-width sidebar, `linear-weight: 2` and `linear-weight: 1` for the remaining columns, and cross-axis centering.",
+      "expectations": [
+        "The container uses `display: linear` and `linear-direction: row` rather than Flexbox or Web block layout.",
+        "The sidebar has `width: 200px`, while main and aside use `linear-weight: 2` and `linear-weight: 1` respectively.",
+        "The answer explains that the fixed sidebar consumes main-axis space first and the weighted children divide only the remaining space in a 2:1 ratio.",
+        "The container uses `align-items: center` for cross-axis centering in a row Linear Layout.",
+        "The TSX uses Lynx `view` containers and wraps visible labels or content in `text` elements."
+      ],
+      "files": []
+    },
+    {
+      "id": 3,
+      "name": "large-feed-list-with-load-more",
+      "prompt": "我要在 ReactLynx 中渲染一个会持续增长的长 feed。每项都有稳定的 `id` 和 `title`，列表要纵向滚动，到底部阈值时调用 `handleLoadMore`。请根据 `<list>` API 给最小实现，并说明保证滚动区域和列表性能的必要约束。",
+      "expected_output": "A vertical Lynx `list` containing keyed `list-item` children, wired to `bindscrolltolower`, with a resolved list height and stable item identities plus the documented performance guardrails.",
+      "expectations": [
+        "The implementation uses `<list scroll-y bindscrolltolower={handleLoadMore}>` or equivalent documented boolean/event syntax.",
+        "Each repeated row is a direct `list-item` with both a stable React `key` and stable `item-key` derived from the item's id.",
+        "The list receives a resolved height, such as `height: 100vh`, so its scroll area is measurable.",
+        "Visible item titles are rendered inside `text`, and the answer recommends predictable `list-item` heights where possible.",
+        "The response explains that `list` is appropriate for a large or growing collection and that a small static child set can use `scroll-view` instead."
+      ],
+      "files": []
+    },
+    {
+      "id": 4,
+      "name": "compatible-grid-item-placement",
+      "prompt": "用 Lynx Grid 写一个四等分列的 gallery：普通行高 80px；large tile 占第 1-2 列和第 1-2 行；wide tile 占第 3 行全部四列。项目不保证 Lynx 3.9，也没有开启额外 Grid flag，请给兼容默认配置的 CSS，并解释为什么不用放置 shorthand。",
+      "expected_output": "A four-column Lynx Grid using explicit start/end grid lines for both special tiles, avoiding `grid-column` and `grid-row` shorthands that require Lynx 3.9+ and `enableGridPlacementShorthands`.",
+      "expectations": [
+        "The grid container uses `display: grid`, `grid-template-columns: repeat(4, 1fr)`, and `grid-auto-rows: 80px`.",
+        "The large tile uses column lines 1 to 3 and row lines 1 to 3 via `grid-column-start/end` and `grid-row-start/end`.",
+        "The wide tile uses column lines 1 to 5 and row lines 3 to 4 via the explicit start/end properties.",
+        "The answer avoids `grid-column` and `grid-row` shorthands for this target.",
+        "The explanation states that those shorthands are only available in Lynx 3.9+ when `enableGridPlacementShorthands: true` is enabled."
+      ],
+      "files": []
+    }
+  ]
+}

--- a/packages/skills/lynx-api-docs/evals/trigger_eval.json
+++ b/packages/skills/lynx-api-docs/evals/trigger_eval.json
@@ -1,0 +1,74 @@
+[
+  {
+    "query": "把这个带 div、img、h2 和 button 的 Web React 卡片迁移成正确的 ReactLynx 元素和事件写法。",
+    "should_trigger": true
+  },
+  {
+    "query": "Lynx 默认 Linear Layout 怎么做横向排列，并用 linear-weight 分配剩余空间？",
+    "should_trigger": true
+  },
+  {
+    "query": "用 Lynx 的 list 和 list-item 写一个长 feed，并在滚动到底部时加载更多。",
+    "should_trigger": true
+  },
+  {
+    "query": "How do implicit rows and explicit grid line placement work in Lynx Grid layout?",
+    "should_trigger": true
+  },
+  {
+    "query": "Can a Lynx view contain raw text, or must the label be wrapped in a text element?",
+    "should_trigger": true
+  },
+  {
+    "query": "为什么从网页迁移到 Lynx 后 margin 不会折叠，而且默认 box-sizing 和布局模式也不同？",
+    "should_trigger": true
+  },
+  {
+    "query": "Migrate ordinary body scrolling to a Lynx page and explain where scroll-view belongs.",
+    "should_trigger": true
+  },
+  {
+    "query": "Review this .ttml page for invalid Web elements and Lynx-specific CSS or layout assumptions.",
+    "should_trigger": true
+  },
+  {
+    "query": "Which Lynx pseudo-classes are documented, and how should I rewrite this hover-based interaction?",
+    "should_trigger": true
+  },
+  {
+    "query": "Does Lynx 2.0 on Android support display: grid, and what minimum SDK version enables it?",
+    "should_trigger": false
+  },
+  {
+    "query": "Query @lynx-js/css-defines and compare filter brightness compatibility across every rendering backend.",
+    "should_trigger": false
+  },
+  {
+    "query": "ReactLynx says my custom-input tag is missing from JSX.IntrinsicElements. Write the TypeScript module augmentation.",
+    "should_trigger": false
+  },
+  {
+    "query": "How do I add appTheme to lynx.__globalProps with an @lynx-js/types declaration file?",
+    "should_trigger": false
+  },
+  {
+    "query": "ReactLynx 双线程里 NativeModules 调用应该放在 render、effect 还是事件处理函数中？",
+    "should_trigger": false
+  },
+  {
+    "query": "帮我分析 Lynx trace 里的 FCP、模板加载和跨线程调用耗时。",
+    "should_trigger": false
+  },
+  {
+    "query": "What props and ref methods does the @lynx-js/lynx-ui ScrollView component export?",
+    "should_trigger": false
+  },
+  {
+    "query": "Can I use CSS subgrid in current Chrome and Safari? Compare browser compatibility.",
+    "should_trigger": false
+  },
+  {
+    "query": "Configure tsconfig so a ReactLynx Rspeedy project recognizes CSS Modules and ?lynx-bundle imports.",
+    "should_trigger": false
+  }
+]

--- a/packages/skills/lynx-api-docs/test.mjs
+++ b/packages/skills/lynx-api-docs/test.mjs
@@ -2,14 +2,21 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 import assert from 'node:assert/strict';
-import { readFile } from 'node:fs/promises';
+import { execFile } from 'node:child_process';
+import { access, readFile, rm, writeFile } from 'node:fs/promises';
 import { dirname, resolve } from 'node:path';
 import test from 'node:test';
 import { fileURLToPath } from 'node:url';
+import { promisify } from 'node:util';
 
 const packageRoot = dirname(fileURLToPath(import.meta.url));
+const execFileAsync = promisify(execFile);
 
 test('builds the public Lynx API documentation skill', async () => {
+  await execFileAsync(process.execPath, [resolve(packageRoot, 'build.mjs')], {
+    cwd: packageRoot,
+  });
+
   const skill = await readFile(resolve(packageRoot, 'SKILL.md'), 'utf8');
   assert.match(skill, /^---\nname: lynx-api-docs\n/m);
   assert.match(skill, /elements\/<element-name>\.md/);
@@ -19,4 +26,23 @@ test('builds the public Lynx API documentation skill', async () => {
     'utf8',
   );
   assert.match(elementDocs, /scroll-view/);
+
+  const stalePath = resolve(packageRoot, 'elements', 'stale.md');
+  await writeFile(stalePath, 'stale');
+
+  try {
+    await execFileAsync(process.execPath, [resolve(packageRoot, 'build.mjs')], {
+      cwd: packageRoot,
+    });
+    await assert.rejects(access(stalePath), { code: 'ENOENT' });
+  } finally {
+    await rm(stalePath, { force: true });
+  }
+});
+
+test('is not publishable as a standalone package', async () => {
+  const packageManifest = JSON.parse(
+    await readFile(resolve(packageRoot, 'package.json'), 'utf8'),
+  );
+  assert.equal(packageManifest.private, true);
 });

--- a/packages/skills/lynx-api-docs/turbo.json
+++ b/packages/skills/lynx-api-docs/turbo.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://turborepo.dev/schema.json",
+  "extends": ["//"],
+  "tasks": {
+    "build": {
+      "outputs": [
+        "SKILL.md",
+        "best-practices.md",
+        "quick-reference.md",
+        "config/**",
+        "css/**",
+        "elements/**",
+        "examples/**",
+        "layout/**",
+        "lynx-vs-web/**",
+        "patterns/**"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Follow-up to #111.

- replace generated Lynx API docs from a validated `package.json#files` allowlist so upstream deletions cannot leave stale exported files; stage and roll back replacements on ordinary install failures
- make the package test self-contained, cover stale-file cleanup, and assert the already-merged `private: true` flag
- declare every generated docs path as a Turbo `build` output so cache hits restore missing artifacts
- add task/trigger evals for `lynx-api-docs`, plus the missing repository fallback evals for the external `lynx-openui` skill so the all-skill definition check is green

## Verification

- `pnpm --filter @lynx-js/skill-lynx-api-docs test`
- Turbo cache recovery: populate cache, move `SKILL.md`, rerun the same filtered build, confirm a cache hit restores byte-identical output
- `pnpm eval:skill:check -- --skill-path packages/skills/lynx-api-docs`
- `pnpm eval:skill:check:all` (14/14)
- `node --test scripts/validate-skills.test.mjs`
- `pnpm build`
- `pnpm check`
- `pnpm test`
- `pnpm changeset status --since=origin/main` (no bump; package is private)
