### PR TITLE
fix: harden lynx-api-docs skill build

### DIFF
--- a/packages/skills/lynx-api-docs/build.mjs
+++ b/packages/skills/lynx-api-docs/build.mjs
@@ -1,7 +1,7 @@
 // Copyright 2026 The Lynx Authors. All rights reserved.
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
-import { cp, readdir, readFile, writeFile } from 'node:fs/promises';
+import { cp, readdir, readFile, rm, writeFile } from 'node:fs/promises';
 import { createRequire } from 'node:module';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -12,6 +12,18 @@ const packageRoot = dirname(
 );
 const sourceRoot = resolve(packageRoot, 'skills', 'using-lynx-api-docs');
 const targetRoot = dirname(fileURLToPath(import.meta.url));
+const generatedEntries = [
+  'SKILL.md',
+  'best-practices.md',
+  'quick-reference.md',
+  'config',
+  'css',
+  'elements',
+  'examples',
+  'layout',
+  'lynx-vs-web',
+  'patterns',
+];
 const excludedEntries = new Set([
   'AGENTS.md',
   'AGENTS.public.md',
@@ -19,6 +31,12 @@ const excludedEntries = new Set([
   'README.md',
   'README.public.md',
 ]);
+
+await Promise.all(
+  generatedEntries.map((entry) =>
+    rm(resolve(targetRoot, entry), { recursive: true, force: true }),
+  ),
+);
 
 for (const entry of await readdir(sourceRoot)) {
   if (excludedEntries.has(entry)) {

--- a/packages/skills/lynx-api-docs/evals/evals.json
+++ b/packages/skills/lynx-api-docs/evals/evals.json
@@ -1,0 +1,45 @@
+{
+  "skill_name": "lynx-api-docs",
+  "description": "End-to-end task evals for retrieving authoritative Lynx element, CSS, layout, migration, and implementation guidance from the bundled public API documentation.",
+  "evals": [
+    {
+      "id": 1,
+      "name": "scroll-view-api-lookup",
+      "prompt": "Before implementing a ReactLynx infinite feed, use the installed Lynx API documentation to verify the public attributes, scroll events, and ref methods available on `<scroll-view>`. Identify the specific documentation file you consulted and do not infer APIs from browser elements.",
+      "expected_output": "A documentation-backed summary of the public scroll-view surface, organized by attributes, events, and methods, with the installed element reference identified as the source.",
+      "expectations": [
+        "The response reads or cites the installed `elements/scroll-view.md` reference.",
+        "Attributes, events, and ref methods are distinguished instead of being presented as one invented API list.",
+        "The answer does not infer behavior from HTML scrolling elements or general browser knowledge.",
+        "Any API detail not established by the installed reference is reported as unverified rather than guessed."
+      ],
+      "files": []
+    },
+    {
+      "id": 2,
+      "name": "choose-layout-for-two-dimensional-content",
+      "prompt": "I need a Lynx product gallery with aligned rows and columns and items that can span multiple tracks. Compare the installed Linear, Flex, Grid, and Relative Layout documentation, recommend the appropriate layout, and call out Lynx-specific constraints I should verify before coding.",
+      "expected_output": "A concise recommendation grounded in the bundled layout references, selecting Grid for the two-dimensional spanning requirement and identifying relevant Lynx-specific constraints without assuming browser parity.",
+      "expectations": [
+        "The response consults the installed layout references rather than relying only on web layout knowledge.",
+        "Grid is recommended because the requirement is explicitly two-dimensional and includes track spanning.",
+        "The answer distinguishes Grid from Linear, Flex, and Relative Layout in terms relevant to the requested gallery.",
+        "Lynx-specific syntax, defaults, or limitations are verified from the references or explicitly left unverified."
+      ],
+      "files": []
+    },
+    {
+      "id": 3,
+      "name": "review-web-to-lynx-styling",
+      "prompt": "Review this proposed Lynx styling approach before I implement it: use `<div>` and `<span>`, rely on normal browser flow, assume `content-box`, and copy several web CSS properties without checking support. Use the installed Lynx API documentation to identify the invalid assumptions and propose the documentation-backed direction.",
+      "expected_output": "A review that rejects the web-only element and layout assumptions, explains the relevant Lynx defaults, and routes each implementation decision to the bundled element, CSS, layout, or web-migration references.",
+      "expectations": [
+        "The response identifies that Lynx uses elements such as `<view>` and `<text>` rather than HTML `<div>` and `<span>`.",
+        "The response identifies Lynx layout and box-sizing assumptions from the installed references rather than treating browser defaults as authoritative.",
+        "The response requires checking bundled CSS documentation before using web CSS properties.",
+        "The response points to the relevant `elements/`, `css/`, `layout/`, or `lynx-vs-web/` references and does not invent unsupported replacements."
+      ],
+      "files": []
+    }
+  ]
+}

--- a/packages/skills/lynx-api-docs/evals/trigger_eval.json
+++ b/packages/skills/lynx-api-docs/evals/trigger_eval.json
@@ -1,0 +1,42 @@
+[
+  {
+    "query": "Check the installed Lynx API docs for every public attribute, event, and ref method supported by `<scroll-view>`.",
+    "should_trigger": true
+  },
+  {
+    "query": "Before writing this ReactLynx page, verify which Lynx elements and CSS properties are valid instead of assuming browser behavior.",
+    "should_trigger": true
+  },
+  {
+    "query": "Compare Linear, Flex, Grid, and Relative Layout in Lynx and recommend one for this two-dimensional card gallery.",
+    "should_trigger": true
+  },
+  {
+    "query": "Why does this web layout migrate incorrectly to Lynx? Check the bundled Lynx-versus-Web references and propose a documented rewrite.",
+    "should_trigger": true
+  },
+  {
+    "query": "Review this TTML and styling change against the authoritative public Lynx element and CSS documentation.",
+    "should_trigger": true
+  },
+  {
+    "query": "Does `display: grid` work on Android with Lynx 2.0, and which engine version first supports it?",
+    "should_trigger": false
+  },
+  {
+    "query": "TypeScript says this ReactLynx event handler is incompatible with the component prop type. Fix the type error.",
+    "should_trigger": false
+  },
+  {
+    "query": "Use Lynx DevTool to inspect the running page, capture console logs, and take a screenshot.",
+    "should_trigger": false
+  },
+  {
+    "query": "Which lynx-ui dialog component should I use, and what props does that component expose?",
+    "should_trigger": false
+  },
+  {
+    "query": "Compare current CSS Grid support in Chrome, Safari, and Firefox for a normal web application.",
+    "should_trigger": false
+  }
+]

--- a/packages/skills/lynx-api-docs/test.mjs
+++ b/packages/skills/lynx-api-docs/test.mjs
@@ -2,14 +2,19 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 import assert from 'node:assert/strict';
-import { readFile } from 'node:fs/promises';
+import { execFile } from 'node:child_process';
+import { readFile, writeFile } from 'node:fs/promises';
 import { dirname, resolve } from 'node:path';
 import test from 'node:test';
 import { fileURLToPath } from 'node:url';
+import { promisify } from 'node:util';
 
 const packageRoot = dirname(fileURLToPath(import.meta.url));
+const execFileAsync = promisify(execFile);
 
 test('builds the public Lynx API documentation skill', async () => {
+  await execFileAsync(process.execPath, [resolve(packageRoot, 'build.mjs')]);
+
   const skill = await readFile(resolve(packageRoot, 'SKILL.md'), 'utf8');
   assert.match(skill, /^---\nname: lynx-api-docs\n/m);
   assert.match(skill, /elements\/<element-name>\.md/);
@@ -19,4 +24,13 @@ test('builds the public Lynx API documentation skill', async () => {
     'utf8',
   );
   assert.match(elementDocs, /scroll-view/);
+});
+
+test('removes stale documentation when rebuilding', async () => {
+  const stalePath = resolve(packageRoot, 'elements', 'stale-element.md');
+  await writeFile(stalePath, '# Removed upstream\n');
+
+  await execFileAsync(process.execPath, [resolve(packageRoot, 'build.mjs')]);
+
+  await assert.rejects(readFile(stalePath, 'utf8'), { code: 'ENOENT' });
 });

--- a/packages/skills/lynx-api-docs/turbo.json
+++ b/packages/skills/lynx-api-docs/turbo.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://turborepo.dev/schema.json",
+  "extends": ["//"],
+  "tasks": {
+    "build": {
+      "outputs": [
+        "SKILL.md",
+        "best-practices.md",
+        "quick-reference.md",
+        "config/**",
+        "css/**",
+        "elements/**",
+        "examples/**",
+        "layout/**",
+        "lynx-vs-web/**",
+        "patterns/**"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Follow up on the post-merge review notes from #111:

- add task and trigger eval definitions for `lynx-api-docs`
- declare every generated documentation path as a Turbo `build` output
- clean the safe generated output set before copying upstream documentation so deleted or renamed files do not remain stale
- make the package test invoke the build itself and cover stale-file removal

Review context: https://github.com/lynx-community/skills/pull/111#issuecomment-5130469365

## Verification

- `pnpm eval:skill:check -- --skill-path packages/skills/lynx-api-docs`
- `pnpm --filter @lynx-js/skill-lynx-api-docs test`
- `pnpm build`
- `node --test scripts/validate-skills.test.mjs`
- `pnpm exec biome check packages/skills/lynx-api-docs`
- `pnpm exec eslint packages/skills/lynx-api-docs`
- Turbo cache reproduction: populate the filtered build cache, remove generated `SKILL.md`, rerun the filtered build, and verify that the file is restored
- `pnpm changeset status --since=origin/main`