### PR TITLE
fix(devtool-connector): drop the internal xdb protocol from the public types

### DIFF
--- a/.changeset/drop-xdb-protocol-types.md
+++ b/.changeset/drop-xdb-protocol-types.md
@@ -1,0 +1,12 @@
+---
+'@lynx-js/devtool-connector': patch
+---
+
+Remove the internal `xdb` protocol types from the public type surface.
+
+`XdbJsbRequest`, `XdbJsbResponse`, `XdbGlobalPropsRequest` and
+`XdbGlobalPropsResponse`, along with their `CustomizedResponseMap` and
+`Response` entries, described a ByteDance-internal DevTool protocol. The
+commands that spoke it are not part of the public CLI, so the types had no
+consumer here and only leaked internal protocol names into the published
+`.d.ts`.

--- a/packages/mcp-servers/devtool-connector/src/index.ts
+++ b/packages/mcp-servers/devtool-connector/src/index.ts
@@ -289,7 +289,7 @@ export class Connector {
    * Unlike {@link sendMessage}, this method does not wait for the output
    * stream to produce a value. It connects, writes the message, and then
    * disposes of the connection. This is useful for fire-and-forget messages
-   * such as `xdb_proxy_config` where the device does not send a reply.
+   * that the device acknowledges without sending a reply.
    */
   async sendMessageNoReply<T>(clientId: string, message: T): Promise<void> {
     const { deviceId, port } = this.#resolveClientId(clientId);

--- a/packages/mcp-servers/devtool-connector/src/types.ts
+++ b/packages/mcp-servers/devtool-connector/src/types.ts
@@ -179,55 +179,13 @@ export type SetGlobalSwitchResponse = CustomizedEvent<
   }
 >;
 
-export type XdbJsbRequest = CustomizedEvent<
-  'xdb_jsb',
-  {
-    client_id: number;
-    session_id: number;
-    message: { type: string };
-  }
->;
-
-export type XdbJsbResponse = CustomizedEvent<
-  'xdb_jsb',
-  {
-    client_id: number;
-    session_id: number;
-    /** JSON string */
-    message: string;
-  }
->;
-
-export type XdbGlobalPropsRequest = CustomizedEvent<
-  'xdb_globalprops',
-  {
-    client_id: number;
-    session_id: number;
-    message: { type: string; timestamp: string };
-  }
->;
-
-export type XdbGlobalPropsResponse = CustomizedEvent<
-  'xdb_globalprops',
-  {
-    client_id: number;
-    session_id: number;
-    /** JSON string */
-    message: string;
-  }
->;
-
 export type CustomizedResponseMap = {
   App: AppResponse;
   CDP: CDPResponse;
-  xdb_jsb: XdbJsbResponse;
-  xdb_globalprops: XdbGlobalPropsResponse;
 };
 export type CustomizedResponseMessageMap = {
   App: AppResponseMessage;
   CDP: CDPResponseMessage;
-  xdb_jsb: unknown;
-  xdb_globalprops: unknown;
 };
 
 export type Response =
@@ -237,8 +195,6 @@ export type Response =
   | CDPResponse
   | GetGlobalSwitchResponse
   | SetGlobalSwitchResponse
-  | XdbJsbResponse
-  | XdbGlobalPropsResponse
   | HeadlessPrepareResponse;
 
 export function isInitializeResponse(

--- a/packages/mcp-servers/devtool-connector/test/public-api.test.ts
+++ b/packages/mcp-servers/devtool-connector/test/public-api.test.ts
@@ -18,7 +18,7 @@ test('the package main entry re-exports createCorrelatedFilter', () => {
 
 test('Connector keeps the published no-reply API', () => {
   // `sendMessageNoReply` is part of the released public surface, so it must
-  // stay available for fire-and-forget messages such as `xdb_proxy_config`.
+  // stay available for fire-and-forget messages the device does not answer.
   assert.equal(typeof Connector.prototype.sendMessageNoReply, 'function');
 });
 


### PR DESCRIPTION
## Summary

Auditing the published `@lynx-js/devtool-connector` tarball turned up four
exported types describing a ByteDance-internal DevTool protocol:

```
dist/types.d.ts:134  export type XdbJsbRequest = CustomizedEvent<'xdb_jsb', {...}>
dist/types.d.ts:147  export type XdbGlobalPropsRequest = CustomizedEvent<'xdb_globalprops', {...}>
```

The commands that spoke that protocol — `jsb`, `global-props` and `proxy` — are
not part of the public CLI, so nothing in this repository consumed the types.
They only shipped internal protocol names in the published `.d.ts`.

This removes the four types along with their `CustomizedResponseMap`,
`CustomizedResponseMessageMap` and `Response` entries, and rewords the two
comments that used `xdb_proxy_config` as the fire-and-forget example.
`Connector.sendMessageNoReply` itself is unchanged — it is part of the released
public surface.

Note this predates the Agent Lynx export: `@lynx-js/devtool-connector@0.9.5`
already shipped these types, so this is a pre-existing leak rather than a
regression from #118.

### On the API surface

Removing exported types is technically breaking, but no public consumer can be
relying on them: they only describe messages the public CLI never sends, and the
maps they fed are used solely as generic constraints inside
`streams/customized.ts` (verified there is no call site keyed on `'xdb_jsb'` or
`'xdb_globalprops'`). Released as a patch on that basis.

## Test plan

- [x] `rg 'xdb|Xdb|XDB' packages/` is empty across source and tests
- [x] Rebuilt and confirmed `dist/*.d.ts` no longer contains `xdb`
- [x] connector unit tests: 238 passing, 0 failing
- [x] Downstream `@lynx-js/devtool-mcp-server` and `agent-lynx` both build
- [x] `pnpm check` exits 0
- [x] `pnpm changeset status` resolves the connector at patch (0.13.1 -> 0.13.2)