### PR TITLE
docs(reactlynx-best-practices): sharpen skill description triggers and boundaries

### DIFF
--- a/.changeset/sharp-reactlynx-triggers.md
+++ b/.changeset/sharp-reactlynx-triggers.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/skill-reactlynx-best-practices": patch
+---
+
+Sharpen the skill description with explicit use-when triggers and boundary carve-outs (vanilla-lynx, lynx-devtool, lynx-typescript) so SkillProbe admission passes.

--- a/packages/skills/reactlynx-best-practices/SKILL.md
+++ b/packages/skills/reactlynx-best-practices/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: reactlynx-best-practices
-description: Review, write, and refactor ReactLynx code and component libraries using dual-thread, lifecycle, main-thread script, package publishing, lynx.__globalProps, code-splitting, and profiling best practices.
+description: Review, write, and refactor ReactLynx code and component libraries for Lynx dual-thread best practices. Use when writing ReactLynx components, or handling background-only, useLayoutEffect, bindtap/catchtap, main-thread:*, runOnMainThread/runOnBackground, lazy/Suspense, globalPropsMode/__globalProps, component-library publishing (preserved JSX vs React.createElement), or render/diff/commit performance traces. Not for vanilla Lynx Element PAPI without ReactLynx JSX (use vanilla-lynx), running-app debugging via DevTool/CDP (use lynx-devtool), or Rspeedy/tsconfig config (use lynx-typescript).
 ---
 
 # ReactLynx Best Practices

--- a/packages/skills/reactlynx-best-practices/evals/evals.json
+++ b/packages/skills/reactlynx-best-practices/evals/evals.json
@@ -123,6 +123,34 @@
         "The response recommends validating the packed package in a small ReactLynx consumer."
       ],
       "files": []
+    },
+    {
+      "id": 9,
+      "name": "cross-thread-runonbackground-state-update",
+      "prompt": "ReactLynx 里我在 `main-thread:bindtap` 的 `'main thread'` 处理函数里直接调了 `setCount(c => c + 1)`，还想读一个 `NativeModules` 的值，结果报错。主线程函数里到底能不能更新 React state、调 background-only API？正确写法是什么？",
+      "expected_output": "Guidance that a `'main thread'` function cannot directly call background-thread work such as React `setState` or `NativeModules`; it must hop back with `runOnBackground()`, and conversely background code reaches the main thread with `runOnMainThread()`. The answer should show a corrected example wrapping the state update / native call in `runOnBackground(() => { ... })()`.",
+      "expectations": [
+        "The response explains that a `'main thread'` function runs on the main thread and cannot directly run background-thread work like React `setState` or `NativeModules`.",
+        "The response recommends wrapping the state update and native call in `runOnBackground(() => { ... })()` from `@lynx-js/react`.",
+        "The response notes that `runOnBackground` returns a promise that can be awaited from the main-thread handler.",
+        "The response mentions the symmetric direction: background code calls `runOnMainThread()` to run a `'main thread'` function.",
+        "The response references `main-thread-scripts-guide` or the cross-thread call rule."
+      ],
+      "files": []
+    },
+    {
+      "id": 10,
+      "name": "hoist-static-jsx-recreated-element",
+      "prompt": "帮我 review 这段 ReactLynx 代码，列表项很多时感觉 render 有点重：\n\n```tsx\nfunction Row() {\n  return <view className=\"h-20 bg-gray-200 animate-pulse\" />;\n}\n\nfunction List({ items, loading }) {\n  return (\n    <view>\n      {items.map((it) => <Item key={it.id} data={it} />)}\n      {loading && <Row />}\n    </view>\n  );\n}\n```\n\n有没有可以减少重复创建的地方？",
+      "expected_output": "A review pointing out that the static `<Row />` placeholder JSX is recreated on every render and can be hoisted to a module-level constant element, with a note that this matters most for large static subtrees (e.g. SVG) and is unnecessary when React Compiler is enabled.",
+      "expectations": [
+        "The response identifies that the static loading placeholder element is recreated on every render.",
+        "The response recommends hoisting the static JSX into a module-level constant element and referencing it instead of re-creating it.",
+        "The response references `hoist-static-jsx` or the static-JSX hoisting rule.",
+        "The response notes hoisting matters most for large/static subtrees such as SVG nodes.",
+        "The response notes manual hoisting is unnecessary when React Compiler is enabled."
+      ],
+      "files": []
     }
   ]
 }

--- a/packages/skills/reactlynx-best-practices/evals/trigger_eval.json
+++ b/packages/skills/reactlynx-best-practices/evals/trigger_eval.json
@@ -36,6 +36,14 @@
     "should_trigger": true
   },
   {
+    "query": "ReactLynx main-thread:bindtap 的 'main thread' 函数里能直接 setState 吗，还是要 runOnBackground？",
+    "should_trigger": true
+  },
+  {
+    "query": "ReactLynx 列表里每个 item 都重复创建同一个静态占位 view，怎么减少 render 开销？",
+    "should_trigger": true
+  },
+  {
     "query": "帮我配置 Rspeedy 的 tsconfig，让 CSS Modules 有类型。",
     "should_trigger": false
   },
@@ -45,6 +53,14 @@
   },
   {
     "query": "不用 ReactLynx，直接用 vanilla Lynx Element PAPI 创建页面树怎么写？",
+    "should_trigger": false
+  },
+  {
+    "query": "我的 rspeedy 项目 .lynx.bundle 太大了，main-thread.js 里混了一堆请求和埋点 SDK，怎么减小包体积？",
+    "should_trigger": false
+  },
+  {
+    "query": "Lynx DevTool 里连上真机后，怎么把某个 ReactLynx 组件的 props 改一下看看效果？",
     "should_trigger": false
   },
   {


### PR DESCRIPTION
Add explicit use-when triggers and boundary carve-outs (vanilla-lynx, lynx-devtool, lynx-typescript) so SkillProbe admission passes.