### PR TITLE
fix(reactlynx-best-practices): use third-person description

### DIFF
--- a/.changeset/fresh-skillprobe-wording.md
+++ b/.changeset/fresh-skillprobe-wording.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/skill-reactlynx-best-practices": patch
+---
+
+Use third-person wording in the skill description so it passes SkillProbe admission.

--- a/packages/skills/reactlynx-best-practices/SKILL.md
+++ b/packages/skills/reactlynx-best-practices/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: reactlynx-best-practices
-description: Review, write, and refactor ReactLynx code and component libraries for Lynx dual-thread best practices. Use when writing ReactLynx components, or handling background-only, useLayoutEffect, bindtap/catchtap, main-thread:*, runOnMainThread/runOnBackground, lazy/Suspense, globalPropsMode/__globalProps, component-library publishing (preserved JSX vs React.createElement), or render/diff/commit performance traces. Not for vanilla Lynx Element PAPI without ReactLynx JSX (use vanilla-lynx), running-app debugging via DevTool/CDP (use lynx-devtool), or Rspeedy/tsconfig config (use lynx-typescript).
+description: Reviews, writes, and refactors ReactLynx code and component libraries for Lynx dual-thread best practices. Applies when writing ReactLynx components, or handling background-only, useLayoutEffect, bindtap/catchtap, main-thread:*, runOnMainThread/runOnBackground, lazy/Suspense, globalPropsMode/__globalProps, component-library publishing (preserved JSX vs React.createElement), or render/diff/commit performance traces. Excludes vanilla Lynx Element PAPI without ReactLynx JSX (use vanilla-lynx), running-app debugging via DevTool/CDP (use lynx-devtool), or Rspeedy/tsconfig config (use lynx-typescript).
 ---
 
 # ReactLynx Best Practices


### PR DESCRIPTION
## Summary

- rewrite the `reactlynx-best-practices` description in third-person wording
- preserve the existing trigger conditions and delegation boundaries
- add a patch changeset for `@lynx-js/skill-reactlynx-best-practices`

## Testing

- `pnpm --filter @lynx-js/skill-reactlynx-best-practices test` (42 tests passed)
- `pnpm --filter @lynx-js/skill-reactlynx-best-practices build`
- `pnpm check`
- `pnpm changeset status --since=origin/main`
- SkillProbe `0.3.30` against the packed package: rating A, P0=0, P1=0
