### PR TITLE
fix(vanilla-lynx): point bundle-size routing at the skill that exists

### DIFF
--- a/.changeset/tall-pots-tickle.md
+++ b/.changeset/tall-pots-tickle.md
@@ -1,0 +1,5 @@
+---
+"@lynx-js/skill-vanilla-lynx": patch
+---
+
+Route bundle-size work in the skill description to `rspeedy-bundle-size`, the skill that exists, instead of the nonexistent `rspeedy-bundle-quality`.

--- a/packages/skills/vanilla-lynx/SKILL.md
+++ b/packages/skills/vanilla-lynx/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: vanilla-lynx
 description: |
-  Build Rspeedy Vanilla Lynx apps with Element PAPI and Lynx Runtime APIs, never ReactLynx or JSX. Use for project scaffolding, main-thread UI, lifecycle/events, background communication, styling, or external bundles. Do not use for device-side runtime validation or debugging of an already built artifact; use lynx-devtool instead. For general APIs use lynx-api-docs; for ReactLynx use reactlynx-best-practices; for bundle quality use rspeedy-bundle-quality. Excludes Element PAPI JSON mode and output formats outside the Rspeedy Vanilla Lynx workflow.
+  Build Rspeedy Vanilla Lynx apps with Element PAPI and Lynx Runtime APIs, never ReactLynx or JSX. Use for project scaffolding, main-thread UI, lifecycle/events, background communication, styling, or external bundles. Do not use for device-side runtime validation or debugging of an already built artifact; use lynx-devtool instead. For general APIs use lynx-api-docs; for ReactLynx use reactlynx-best-practices; for bundle quality use rspeedy-bundle-size. Excludes Element PAPI JSON mode and output formats outside the Rspeedy Vanilla Lynx workflow.
 ---
 
 # Build Vanilla Lynx Apps


### PR DESCRIPTION
`vanilla-lynx`'s `description` routes bundle-size work to `rspeedy-bundle-quality`, which is not a skill in this repository. The skill is named `rspeedy-bundle-size`.

```
For general APIs use lynx-api-docs; for ReactLynx use reactlynx-best-practices;
for bundle quality use rspeedy-bundle-quality.
                          ^^^^^^^^^^^^^^^^^^^^^
```

Evidence:

- `packages/skills/rspeedy-bundle-size/SKILL.md` declares `name: rspeedy-bundle-size`
- `packages/skills/rspeedy-bundle-size/package.json` declares `@lynx-js/skill-rspeedy-bundle-size`
- No `rspeedy-bundle-quality` exists anywhere under `packages/skills/`

`description` is the field an agent matches on when selecting a skill, so a name that does not resolve makes the routing hint fail rather than just read oddly. An agent following it looks for a skill that is not there.

I checked the other cross-references in the collection — `reactlynx-best-practices` points at `lynx-devtool`, `lynx-typescript`, and `vanilla-lynx`, and `vanilla-lynx` also points at `lynx-api-docs`, `lynx-devtool`, and `reactlynx-best-practices`. All of those resolve. This is the only dangling one.

Single word, no behavior change. Targets `main` per CONTRIBUTING.

<sub>Replaces a previous PR that was closed for housekeeping. Same change, no content difference.</sub>
